### PR TITLE
Improve dataset fetch and process pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,14 @@ else
 endif
 
 ## Make Dataset
-data: requirements fetch_data
+data: requirements process_data
 
 ## Fetch and unpack the data
 fetch_data:
-	$(PYTHON_INTERPRETER) -m src.data.make_dataset $(PROJECT_DIR)
+	$(PYTHON_INTERPRETER) -m src.data.make_dataset fetch
+
+process_data:
+	$(PYTHON_INTERPRETER) -m src.data.make_dataset process
 
 ## Delete all compiled Python files
 clean:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VIRTUALENV = conda
 # COMMANDS                                                                      #
 #################################################################################
 
-## Install Python Dependencies
+## Install or update Python Dependencies
 requirements: test_environment
 ifeq (conda, $(VIRTUALENV))
 	conda env update --name $(PROJECT_NAME) -f environment.yml
@@ -24,13 +24,14 @@ else
 	pip install -r requirements.txt
 endif
 
-## Make Dataset
+## Perform the complete dataset generation pipeline
 data: requirements process_data
 
-## Fetch and unpack the data
+## Fetch the data
 fetch_data:
 	$(PYTHON_INTERPRETER) -m src.data.make_dataset fetch
 
+## Fetch and process the data
 process_data:
 	$(PYTHON_INTERPRETER) -m src.data.make_dataset process
 

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - imageio
   - opencv
   - umap-learn
+  - joblib
   - pip
   - pip:
     - -e .

--- a/notebooks/08-kw-add-new-datasets.ipynb
+++ b/notebooks/08-kw-add-new-datasets.ipynb
@@ -1,0 +1,486 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import src.data.datasets as data3p\n",
+    "import matplotlib.pyplot as plt\n",
+    "import src"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.paths import interim_data_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o10 = interim_data_path / 'coil-20' / 'processed_images' / 'obj10__15.pgm'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f6e4d3668d0>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQUAAAD8CAYAAAB+fLH0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzsvWmwJcd1HvidqrrL21/v3ehuoAGwCYAAwQ3cJYoiRYvUUKI9lmTRsgxLnGA4QmPJDkdIpPVDMxF2hBR2WNLE2PRgRFmUrREl07QI0hIpCSJFS+YGEOACYm80envoft399uXeW5U5P845mVnLazT6Lb28/CK6696qrKysercyz/nORtZaRERERCiSqz2AiIiIawtxUoiIiCghTgoRERElxEkhIiKihDgpRERElBAnhYiIiBLipBAREVHCpk0KRPReInqKiJ4loo9s1nUiIiI2FrQZzktElAJ4GsB7AJwC8A0AH7TWfm/DLxYREbGhyDap3zcBeNZaewwAiOiTAD4AoHFSaFPHdjGySUO5jkGyoQRIEv3C24TcZ5uQPyafLZX7sAnBShfuWIJL7gNZt0+/U2Ld5fmSFikZ2cfHUtkSLIwMYFCkAIB+noJ63GG6CtkWoLzgLwX3BcNbCwDR63ZDsICZ89baPS/VbrMmhYMATgbfTwF4c9iAiD4M4MMA0MUw3kzv3qShXL+gjP881OmAhoflc5sPtluwnRYAwAzzPttKUXT5nKLDL55p8zYfSpB3SD5D2hAK95m3+YhF0eGX0AzJC9rhFzbrFGi1c97V4m23PcBouw8AGMoGAIDxFr/traTASsFjfHFpHABw6vwk0mN80Z2P83Umnl5Aem6O72FhgberPd5aC9vrvZzHFrEG/sJ+6oXLabdZkwI17CtN99baBwA8AADjtHPbLgXZLYcBAIv3HsD0a/nPkd+9CAC456YpAMCrxl/EzZ3nAQA3ty4AAHamixgjfgm7slKnBIwRTwId4r4MZBVHglQkiwyptPeUUmG5XY4ChazMeu5AjgHAQP6MRbB6yxqPXuWv2CIvZLTl2qPUQucHeGxTxTIA4HOLd+DfP/0ObvjlmwEAex7jiaD7/HnYRW6HnCcis7wM2+eJKEoRG4/NmhROATgcfD8E4MwmXeu6Q7pjB2bedwcA4Ozb+Ue999YLeP3keQDAwaFZAMC+1jwAYCJdxmTKL8aFYhQAMFsMI5HJYNW0atdYNp3S9wIJetKuUJHe+D//wKalLQD05HgvaJdrO8PbhAxy+bxUsMSSyMQx2V5x57UTfqEnshXslfs6LBPc64eO4z+/9jkAwLG7dwMAPnbinQCA5794Mw7/BU+S6XM8SSZjo26CsH2eGM3KSpwgNgibZX34BoCjRHQrEbUB/BSABzfpWhERERuITZEUrLU5Ef3vAL4AIAXwO9baxzfjWtcVEl5RZ3/4Drz4g6Knj/BKt9xv4fj8TgDAiYUdAIBWym0SsjDCBGYiHRgQWgkfL0zi9ukqndvyfG8sObJPCUHdH8IG+3JpnyZ8zSwx6BdpqX0rLdDPs1I7PT+8TpZ4MjLsDwB2dJZxeGgGAPDqkVMAgF868qcAgNP/YAf+v3cxHXXiz44CAA5/fhY0xVIViQqUZhmMcA+Rg1gfNkt9gLX2TwD8yWb1HxERsTnYtEkhoo7+e14HAJh6h0HSFZ1YV+U8xcwSs/JZKiupSArdVu7MfKvW/8kIzBH0ZKUmsq6/dpZLG0ZhyR0LpQOVRqoSA1Bf+XOTuH0qnRQmAcnYBoWs2mK2NJZc+34gpZiKZLE8aOHc8hgA4LlFtpjdMX4WAHD30Cn8k5sfAgA89Q9uAgB87N53YOef3g4A2PX1aR7shRkkao5tizVmhTkNK/xDxOUhujlHRESUECWFLUB22xEAwMn7hJ0fX4Hpi77e9atYKhJCO+PVO1ypq3xAmhgUFalgZnEYq8u6SoruX3AbKghJXz4PROfPgUQ+C1UBynk/ACRi9UsGsi2s36d2SGPdypJpu9y69oX4SQzG+TpztwDFbezH0OlyZ0linbQxv8pWk+kVdmZ7Ymg/jo6eAwC8fpTN7L9236fx0NFXAQA+//XXAABu+ewODD0qZvhllhAS8e2weQ6zvIyIy0OcFDYTQiwu3r0XALByWN62lcx5bbiXPDXoyGQw1OK3S0XuwiQl0g4AlnttzJ5mh6ADf8Uv3i2PzyJZZvMdevL2qtdjrw8oESc2/pKLu3EDgh2UxW1KvGphC5kNwnPlGulOJkgHr7qFxz/ZwuTXTgMA8pNskd4z1AUdOQQAOPH+Xfx87uwhEwcpkolwtc+q0dzyEM4tsRn2ifn9AIC7J6bwprFjAIC73slmygfvvBcnP/8KAMDhz4lK8aKQkQCSEZ5kVJWIZOTaiOpDRERECVFS2ESkOycBALOvECJwiMVmO0hAbfFCzOqmulUh4lQ6aKWFI/v6OUsPczMj2P8/eE7f8eXj3O9qz63kbqsr4yAHjMr8lwARkg6L8DQ2JlteZc1oF/29/HnxEKspCzcTevvkWqnEPIjK0ppJcLC3DwDQnWcJxvb7MM/yeG/+OK/kC+94BV58C/dnDq6W+ur3EyxYHs9Sj9ssD9qYGp0AALxmnL3pf/rg1/DwT7Ka8SdHXgsAuOWz/PyHv3USdnGJx5aKWtXpRGlhDURJISIiooQoKWwiBnexH//SQYn4G/g5OG3xvlbL6+9Vs6CSb4VJnAlwRVbL7rMdTDwpQUQaYRjEKASdrn0McLyHmkvPv7qNwbg4QA0L37HC4+rMEtpzvK+9yNt9D+dozzBH0Tor45nhrVlYcBJL0eCCXMhKPfzpC3jlo8xDnPqxgwCA+VdLn6N9DAapPA8+7yINYUGew/lVllxePXkG94jj067vY6nkD3a9gb9/5gh2fvkEj2meA64oTUHSoRFX6cuSpLYB4qSwiciH+cdsuvJCqCUgT2C6/APMRR3otPIamah+BUSenXd+CItAOscisbPDG4s182NQAtiGH728CMPPsCg/smc/VnKegHSOKoa4z6VRi8VbREXIhVxczdBaYFKwPc8v6NAFJgSHpgdIV3hs6TxPAHTijLMEhKRlfpxf2pv+XyYJ97zpTgDAifeOwNws1gT1hxhkKMQnYqpgsnU1b+HkCBOd944xufmPXvU1AMBf7TmK40eOAABu+QzfJ86chRU/j6TFW7vagx30m5/fNkJUHyIiIkqIksJmgQj9CX68tls28VkYtNsVsx9ZFwuga73zTQjaDfrc58R5A6jpUD35+oUj0lQkdqvxS4jG+bHjAIDJk2ew8zZWe5Zv45XXZkIcLuZoTfMqn8wJcdhpYfU2MS0e4BV3MMzte7e30dvBJGEqYv7Bv7CwTzzL9yxjtXnuxy1eiOmXvgkAeMXZozjxY+zluHwXSxtJ2ocRdaov24vLQ46gzWXf3eNsrnzX3qfwN+/lZ/X00K0AgCOfaSE5zsehz6jlX4ftLDFESSEiIqKEKClsEtKJcSzv5jlXzY+2J+awLIgedN6L1nkoapxDyDEUho8Vi/wn684UPtGIrnRJ4jkFdTjKA4IxKUc4NkoPr3kljv0o6+nqybjzSTE5Jhmm7+VITpvydt83VtAf534vvEbyKDzF197/uReQny6n0SiIvIRQ+OuvFZ9QPPEMbllk6eHU/8oSzMLrLbJOLrcspGieQn0WT8yzhLOcMxn56skzuHeCeYb+9/G1Xyhuwa3/RW7wDMdZgAjUZmmHUok8XV1tHNeNjDgpbBLsag+ppCLSvIZWX/JBAiMvuUulSNZNAjoVhCHIXbFS0JAEMGWZtyy4bTABOKtD6LV4Gez6d57B7lvYzj/1fXz9qbfJOAYJjExwmqpt6XDHuUin4kad6dvZaTtPQp24rLXB2C4vUCk/yVaFg59gy8Hs2bsw9U7+6WbjMjFmhVMpllbbpfO/ZQ/izgl+8V+zgyeH4h0JnifOA3Tkj8WP5PhpNzZ9auoqvZ2SuET1ISIiooQoKWwSrLVIRTpV+zqJb4LNE2fvC9ce9UVQqIdjeCwRT7+8mzhR14ne1palhTWgqx8AF+egxJrt9TD64KMAgKPHOKlJPsFkYeepM8jPsskw2yfk372HMHermPbkfjsLIs0Md10W6tB70JorW3GLWfZ/mPjsd2CyVwMAzv6ApKIb8aqEC+UWc+/FlWE8CfasfOU4ez3eO3kavbfyz//U0gEAwOHPDYCpc3Ixuaj88ajd3jYekFFSiIiIKCFKCpsEardhKk9XvRjzVZ9ezZVbCEySSji2QkkhcGQCgP4oAZkQh4G3oiPxkrX19TCMOOl2ZbwSRdjrIRnnqMSzb2LCceEItz3S24eWpJ0/+17Wx+duB7rneWw7n+RrLu/lMZz94A7s+zr3MfrV49z/8grsEl+fJMbisuMydPxLS9j5uScAAEWbQ6jPf79BIqHn1pQ9Q40lXARLR8dTNp/ePDyD2yfYkekrb+T7vfDibuz+ojwbGaNKYZSm2B6MQpQUIiIiKoiSwmbBGLSWJXZhiR/zyG5effJeimJV6jIM1Z1k1AoRxkJ0JZHK8DDrtcs3DcMO8yoPjQAEarkQnBlyjZVYTW5aeAYAioucRHX/Zzhnwdjr2BQ49fYRrOzjFbcYlVRxL2bY9wj30X6U07SP7OHVuDuzB50LwlVI4hOzuOhYfNs3cu0W7MuMO1B+Yc9/e5L7bd2Ji2/hY5qbQV2hdQswvwBwGvo9XXbAOrL7IgDg6bcMY/gc8wtD3+SELaRWk5c1uusbcVLYJNBQ139e1dyFknuxUyBfFm/HhtyIodoAAL0ixUKPRe3hDr9k53YYDHaz2Ns6z3UiUBSO2HMvuf6o1+IfE+9VWEX+IpvxOn/K28NfmUB+1xEAwNwr+OVaPgC88F4em/nRu3g8i3xPw1NAZ0YIUgkjJyLvn+DCvI1TJRSXS+oVMzyB7fvyeSwe4poR5nbJzahqWMuHnms+y6W8jW7O15zscPvRg/OYPco+DsPPiDolBGw4ad7oiOpDRERECdtn+rsKUOel1hzPvas9Np9Nji/jfI8TmKwssaNNpzVwJKL+UUxAOHYk67K2SW9axsW7eDXbf4KlErtY+AKtFYnBFkWz881liO3pJCc0mfr7d2PhNqnVIFU8dj6RY/Z2vsYKW/2w+1vcpjOT49wbeGzmzUxMHvyrHUifZNHcjcbaumSjdtzLdBgyx05gz2PsZXl6Hz/n1jhLG3me1CSyOeqik7J0tLPD6teBsQU8fQ//XSaeY5Pr8Ne5mhVo+ygQUVKIiIgoIUoKmwjNatye51VqcYZXzWx8CWM7mHRcnGXdfHG5i4lR1m1Vm1ZyEfD6sSZz3Tm+jHN387kTxyXl2aMvgDIl8YTAFBMlpekV1z8oJJXa7m8voz8hRF3B1xl97AxGnub7OvF3OEHti28Vd+elDvJRlhqGz4jkMig4twO8+ZRamXeiCh2xAO/5Fe5rgO31MPEocx8zd3B9iP49UmcSxnWjCVsSslgaSMIa8TIbygYY28+u1BfuFm7hOd7iwszaD+gGwxVPCkR0GMDvAdgPwAB4wFr7W0S0E8AfAjgC4DiAn7TWbp8nKqChIZiWxgzwvnSBf5ALK10cmmRy8IUB/wkGgxS5sORhuTjAl4rjY1Ictkgxdgsz8OdfzT/cQycnASUdXeIVYfg7He9J+HIzDEn79KvfxZFn2bJg9rGobiZGQRKmfegvWNQejAtpSHBJVqwEaPV3dDH4wVfyuWIYybsJCjllx1Orci3RT6wJPCADtrQpk5NkjN75JE+Spw7zS9+a7MGKspJlPjxdQ63n+lyEJyWDESFyz+8Vz9E9rE5k22hSWI/6kAP459bauwC8BcDPE9GrAHwEwEPW2qMAHpLvERER1wmuWFKw1k4BmJLPC0T0BICDAD4A4J3S7BMAvgTgl9c1yusRee6YNF3o27O8Wi5ND2N5hNWHO/ayr/2xmZ1YXGIxXIvBKAy8CK0mNQAY67Kice6NLN6fXdiN/V9Y9dcHfFg1gERiJUxPBvQyo/5snsOOsvow/UY2MRZtQjqopJGTpYYMULQkM7T6JiTknovmeTSpP0dT2LWE3DSzc3CBCKp2BOqG1qSwee7Mh0Mv8jPIFqQYzATV0tkVhScftShvOy2cymYOcB9LB/lvMvlc6/If1HWODSEaiegIgNcB+BqAfTJh6MSxd41zPkxEDxPRwwNsj0CTiIjrAesmGoloFMB/BfBPrbXzRHVnnCZYax8A8AAAjNPOG8/ekyRudSRdrGUKThdSTF3glXDyIJOLd+4+h2cusBlsTgrNKtppgY6sYLoNS8lNjnEf02/sYOgCk2wT/1PMfgMhNPoDTzpqAdZ+/2VLC8UxTrA6eZh5jDPf13V8gJOMlLpoA6ZV9pqyZNGe5wex63u8GBSdBFNv55U4H+Kx3fQiOyJRkBHacyGZr98goCxzJGV2jrmNzkU22S7tSZHKGDUJTZL4+BMlHAGfAk/rcfRH5fe8jZyX1nWnRNQCTwi/b639tOw+S0QHrLVTRHQAwLn1DvJ6hB3uohCiUUVjVypuQBjM8g/x5AiL4fftP4n79nNhk8emOc35spROy7p1d0T98QLASJvF5vTQRZz+ISYC0z67Jo9+QyYHa50qoT4BRHTp9OZNvgLSrvX1pwAAtz67w2d5qpSqg/XZpZ0fQiuD7cik1OF97akLuOUL06VLXyoA/CW9HSV/ZPcCX3t5KUPRlxDuEfH9aOdYTeT6QuzmNvHJVSS4yk147ag+vCSIRYKPA3jCWvtvg0MPArhfPt8P4DNXPryIiIitxnokhbcD+BkA3yGix2TfvwDwawD+iIg+BOAEgJ9Y3xCvf1CFcAQBiaxcs9NSPLWzD6/fzZLCm/fx6v7EHJvWZpaHnHmyqkYAZc/H/UcuAABOvJ9Nhgc7RwAAEw9PufZWpYMkQaJJULTo7GX6Mmgfy3cfwPl7JdmLCggB0aifrTosti0GO8RMKunbDv3lOEa+3Fz8lmMltJjOZWZY1oQxeu1u4WPUXeY6r+Zq9uekSEsSGI9Xpb3LU4tvBKzH+vDXANZ6Uu++0n4jIiKuLrYPe7JVUH263YJNy3Omc7838EqzVGM6e3Ecj2cctvvmXccBAD+492kAwFcv3orTc2Ki60gJtyyvlZkDfCboPYfYienM+znJSdG6yZVOc+PpD3xKNyXzQknhUh6Eshq3v/AwDn9tUi6udkXpgxK3T6Mgza5xnH8Dk5Tn38rtTr0rxdGzXDbOPvzdyg2lno8QceMlpRkhIXWVTzoF0pZwIS1fmWugjmPCKSi3AABGHMnSvkgs1ZD0Gxgx9iEiIqKEKClsEmxKTqc1FeKabD3oruinOHleVlwcAeAlhh/a8wSeHuH6jN8Sk+NSv42hFuv17USsCmmO1ZwvpseGb+LtzN8bwsLN3O/NDzLTT+dnnTVBk7nadht2VfT7qikwSetWCmsxuJtX+Rfez6bUfCxMNS/3PJBVOye3b+QYj3X3twdIT/GYjCaV1WjJPHeSweXyHSR95MM6bOvdm0W6yrICHUmbr85iq3nmjmu6+FTLPuQv0zX8OkacFDYYzgegncGo+qATQEB2VSV/awhWfohn59nf/rH0EADgjTtfwGtHWfQ/1GEf/L++cDvmehJgJUlZWmRcOLB6QWpil92jS5j/fv5hPzvJPgCH/3wc3adf5OtLuTZqt1whFCUTX4qETP6aeebbvso/p+SVtwEA5u7egcWDLMrrC9oft8ikirVWsO5NpkhfxWbY7vNMlJrpC/JgbMkr83JQ7OPJtbdD624EOSxJCUwgSys+FJbQlwzQWnRn6OL2mQwUUX2IiIgoIUoKGw2tMJQF862aJJsWHV25Eq9PqLlsap5Jwv9pbsPdk2xSfOPo8wCAOw5O4auLtwMAHpthiWJmdQij4sikbjhqysxt4syYO1/DovrzN41j11+xk9PeL3KEoZ1f8J6PWdnxyPR6JbHe34Nkmr6Hox+f/hkeN+WEg19maSNb5vNOv6PrSttPPsfHkr7BhXtY6hncx+rRoYfYVJu+OOOzVgcwErVoFtlRCda6alSzR/ncfI+oVw02sjQxLhpVCdvCkDfvzohj03yvfr83OKKkEBERUUKUFDYYrjBpmgRFHXjjCEfyjkwkJkkMeTGCKtmc51a7eHyWzZVzAybz7hs/jveMs/nu7WPPAAD++8XX4IkZdnhSqUBzMSRkMdJiKUL5hmzfLPp/l1fhJ+/l/o98dje6TwnPQOWIy2So63mGMDeDmi6fY+ervd+4GwBw/rVwOSXaj7GEc3j1Zhz7u3wPx39UJJIig5ngFXn0CYmqHMjzSBOYcSFBVYIZFCDNYL3qWVy6maWMudslL8XwwB3T6lEqHWSpjz1VHiFNLBaXuL/2jBCjve3HKcRJYaPRErt/FlgfRPp1gUIpYNqiZkgZOBTk/ho2KCwLsKirnnZTyyyaf8XcjuVxJjVfP3QcAPCP934R3xi7FQDw5RkW5adXR/3QKuIyWp6k7N7FWYtO7J1A95tsTdDiLu05frnS5T6SVd7nBPo8mBRkQpz8Dov2I6eH0Z/k57H6BiYfk8JizyPcvD8mL++yRfeCfmbCs79LJoJ9I46wtZlsU6B4FZOJGrC0dJCwcitPeiOTnHxmJJwAqDwptBKDpX5bhu3DqvPzrMbsmJJnvyhxFlF9iIiI2K6IksIGw5FyWeJjALTyepNTeGAiuxQcGSadXuwN41vzUrpN7H13DZ1xUsNbhriQy7d7bOr7H3N34Nl5NkWqdJCSQafNK6D6/x/ZdwHJ+7ic2sp7eJU/v8oi/dJyB8a0Zbze3Kdjz8Ter3Z/Y1cBrJb2pYlftTVgOcxFaSqqU0LWSSVJ4Nyhx7W6xjh8ejVTkbQI3iqsXoudNMfuocVS+6em92Joiq/WmZMkLoPtpz5ESSEiIqKEKClsMHw24mBfRQogC1BRybVAdZOkrt55kbqYhiToeLWQYq895hnm8y5eaLM08Iouk4Vv6DL5987h4xiwUyS+0+cPX5q/EyeWOA4hIclyjNz1O9pmfXook6zIo0tuTMp75CZxK7JuB9LGWHLjzgIHop7wI1oJKyHr0swpQapemq20QFuK5XbFMWsoHWBIMjAnQqSOpj3saDH5qKVgh5Oe244kknNC2p/Lx3Gix7knvj0n+SvOD2NSyjwkfU1+oeJejJKMuEKo9QFATX1Qutsm8JPGQMmzBLaSpYgCojEMlQb4RcqFwZwbsBCd2wS55X09CR5aKJjpf233BPal/GK8rcuk4g90zyGRH7sRsnDaWFwsuL9Zw2pJX/o0SDCWMBHYEqeLFMa9hF3K3dgAYIRyDFfepZTIiaepPJAW+WdWXKJqowkCtLRd+MQKOa4Cv6aONACm5Tl8u8cq1/eWb8J3Ztha8fwZnkjb0xnSFXUqkU5eZmaqGwFRfYiIiCghSgobDBqSoKDhFLLAum2YfcLtE5Nk0iq8GJ6UVycii0ITgaQBESf9JYFqoerFohRPnSI23aVksNpmlWJSxWoq0K2s5JMJYTJZlf54q6vxqrVu9e1bv56oxX9gy2vMBdPBgpy9ZKWUGxUYyM0PRJopGtJy6LEW5VgyHbm++BBQ4aWX4JrarpC1blEknoWii1OrrCadWOTtucVRzC9ILswZqQ+xQGitSBFg8cCkZXkGvctM8HIDIEoKERERJURJYYOh2ZMp1EVteUvWezS6UN1BCkqb9dfCJKCsbDpsJd5Upvt6lCGT/ZpvVE2YfZthwfDKqCvpAgpH1CkvMLCp4wtmpf2LOUsbS6ZTM/f1TAsdKYGlEsCymC0HJnPEnl7H2MSNaWDrMQ2KNKiKpe30vFDa6BkhKJO81l6fy3w+hBmpArUomZt7gwxmoGnYggtXI1qVaDSXSiV7YyFKChERESVESWGjoRJCKCg0Tb1VM2XAI+QSD5FKvH9eJM7NWeMXErJop2W2PyGDvqycPV2ZpdDOsmk7PbylOj1StOCtCABLEUuy0l8o2EV6QXTz8/mYW4VbYcinMPurlWwyKRnHhTRBpYHCJq5fHUcoCSlPont6JnPHQwlBoRLCouRnXylaWOhLFKY8xzxPXCo8NQ+TCSxF28/o4BAnhY0GqYmR6olURD2wBNgKmQiygcRaJxp1T64iNIqaKJ8Gvg4J1cVdI4KhiuEpGfcSKok3sJkj7JYrBF8C685114H1L3TwkgM8cVRVhW4ywMA4H8XaGFW1Sazek3HqSDgRLRft0r2rGgH4iUXBploZhwQ/WZP4rFC6LfznZCAfNDfjy0z0cj0jqg8RERElRElhg8EFUYFsqQBoDSLNwrs5umWqnCqMt6oWeJ995zVYpIHawERfYQmjWb/UTlfqLg2cBDCc+gpLq4GpUL93xftvwXQRIiT/koCYVIQSCMBqh1MHpP+BSZ3oH0od3WRQ2qcrf4u8RORNn54MdZJC8FO+FIGpfVlLQaGKoIGqfxoaroVxt5ETU5QUIiIiStiIArMpgIcBnLbWvp+IbgXwSQA7AXwTwM9Ya7eN54er02hsPf2aIxmsN0mGyVyVI5CYAD1UGHIRgBpRmJDFkCxxSqyZJMG8uDyPtyRBSiAVtMQNeQBP6qWVFb+FAheFYFTi0DsbpZjIlgEAy0LipWScft+qVNLtmcwRgYnQhAPrqzDpKt+iwvEMtTiKQCoogjXMSQOygHeSHCtFq3SuuoGH9TE0kS3IAlVeB+UqXtx/UKmq1vrGxEaoD78I4Alw9CoA/DqA37DWfpKI/gOADwH42AZc57oATfBjMBnV0rg7JKjX1iKfdViJRv0BtzPv7ejY/MT4wKUWv/h9k2Is489ZQ0JI9f7TiaCwCQZQUtBPGEmQrSlEYRPnJejVAW9xqLZv8h3gcVDtuCMYUU4Ek5AnMsPzqn4KPZOhJeNekeeiHpb9InMTkSsLZwnINe0870r7nAQG4EmdL6rM4/YRqtd1p0R0CMD/AuC35TsBeBeAT0mTTwD42+u5RkRExNZivZLCbwL4JQBj8n0XgFlrrS4BpwAcXOc1rit49SEoJOIOyipUwJNbxpNdVYIxTExSJRoTsqVwZIBXUhWhNbQ4JOS8GC4rJJjRTvjmAAAgAElEQVSABHwkZGET7Eo5+chsMSL9ehOjmgc7Ilm0qHBLS2h21PHoSu5rUxQoyIdW83gSNzaXTZmKUp/aTrdLor5oWPVQOggK7Zb7ykKfB3l+1sCN22kiSUMh2XRt0vJGxXpK0b8fwDlr7SPh7oamjUI0EX2YiB4moocH6DU1iYiIuApYbyn6HyOiHwFnxRoHSw6TRJSJtHAIwJmmk621DwB4AADGaeeNw+G0vY6d9STBiFREyiW5gCUb+Nb7+H0taloU5bm6lZhSCjWATZTDWZm/NZack46ujiaYp5U3aMGvnJozQY8ZJJjOmRdRc6JyDKHHouZrCJO+OEeooJ2u7lngUKTSw6iSoNbUiuWGDktVb8eVooUROVePdZLc9VuYsgmzHzg2udEGOdqUfkkGFmlPSF7hFjSWJcY+XAastR+11h6y1h4B8FMA/tJa+9MAvgjgx6XZ/QA+s+5RRkREbBk2w3nplwF8koj+JYBHAXx8E65x7ULdnDNC2hc9eqEsKRTdsikSAGyeODdolRR6g7IZsoqqm3M78VGP/cD5B+BVVnMUKFIyjlNIgtgH7WNQyVnQosJJKioNFEE7Z5K0/nyVBkKOoMofFEhqXIJaJnKTYFicqUIzZOjWDLD04Mcpz0COJbA1ywiAciYsaFFgleakiabs30bcwoZMCtbaLwH4knw+BuBNG9Hv9QirxWAygpE6BapGpKJG0ET9PEp9NI4Lp5btwCSucKyqEblJYOQH3BVSMSWfZEW3+kIBXkXQiQDw8RCKNhXOy1ERxi+YBtpIX2QlObOkbtJ0oj0S98LrvuG0766hfYQ+CRrYpBhKB843Q/uaz4fc8UGlr9Uic+11wrV54gOhGoKg3L48xj5ERERsc8TYhw2CmiLtkJSiT8lXNpKpt73Ay09/glyR1caw6goK46P8lCPsZLnz2AujI9UUuavNZkXNaNyi3In+YTSjSg+K2WLYJXtViUFNjL0iq0VJAn7FDz0UAfFerMQh5CZxS5G2nxkM1/pUtaNnMnRSLx3pPr33UKLwCWOkVF3ipauapFAQEkmam/RFolu2SETloxUpjycVq2LsQ0RExLZFlBQ2CFZ0zqQX1H1QIkvIx1RqCYxMee6h35IVqF3Usornxdpzdm4SZ5LUuIFWUvhIQtmnq/0YeU+qcj4FkV5kRR9Jeo6w03wKA3gSsElSqKdoy2rHmqDHRtNezW3ZpWBD4nIrhOZHXc7UTNlHhhVJVqvPQO/DWHIu41km7VsGNiunczetoF5lS4rZtsQZrd+PsQ8RVwj5ASe5rQXXFPKDowLozMi+ISn40k3cj1RfI828FL5YqkYMJQMvrotPQtaUWEXajyQ9NwEouZjCOO/GqlWhqY8EtpZIBfBkn760IcFYPdaiwr34jkiFDwNX9UdJwjB0Opx0qhmX2knu4j2W8jIxGV4rVB/c4yqFTvOGthGxWEVUHyIiIkqIksIGgTKxZ3d566LsgJqjt02A1qKYDKd4BVtGC/kekTK6QqxJ6rAe/Co51mECbiX3K7qWWBvAJzDR9ko0rpqWC8lWk2QK68g5TagysJlTOYogqQnAKdCq9v6BTb3ZU1beIpBEqurDwKaN+3IXTl2WdsK4CC03N5T2a5GTxibOFKnqQx6oD4UrdycdB0lWnEdj7j0ZKdeb4YM2lqKPiIjYroiSwgYh3cWVh4qOSAwN1aB0W7SD6k6yyHYuEIxIG2afrpb18u26MqaJqa2qnSR3TktOX7dr/4n7NnXmu1JqtECSALwjVCupJ2JNYWrehYrQU1FhLJUSqGgfSgT2jEZ59kvn8P0p39B29+6dl7qlalEA0NccCiZ18RBF7k2kjU6O6mGaSaZn9WSk7bN+xklhoyA/HpPVfzwuy5KrMI3AMiGn94Ghs+rezKJ87ybt2qDTEsIuyFq0WvEgbCWexPNqhA9Zbgd5GAF++cMcjnrMZW+uivK27o5cKtpiyj4JKUztZeqZzIVd6wutpGKIUD2oqixZ4snH+bwr7bx7tv6oNdy8lHlJwtHzYLJ0bs7B/EUD0SkG20dtUGyf6S8iIuKyECWFDUYxJI+UCEmusmjZx94mdZXCkk+n2D3P7XuWV8GVw14asCIxpIkpFUwBOJvziMRI+KzIvAqHmZm1nLxB4gKhVDowNkFfVlFNvdYLVlW9Zlh3oWoyVCybticJnRkywYo715eSc6u89J8HUoepiPkJGdeHqhm5TX3sBZU9IMNkNE59KMgRo6KVIO0DaU8Kyy7KM+pvm/SiDlFSiIiIKCFKChuMoiPzbFBWwCcB9RKDKzmgC6JljzogiJWYEXJsdQizN/GfanwvxzS0U69X64qYU1orB6/kXJcGpUQqgA+XBjw3EFZhcglchWhcDeIYlA8wltCzvGqnVlf7MglY6rfU/9rVnXJ4E6W2cyXxinaQck2rXlHNeSuUXNJaRS40woinKcST0aVji7EPERER2xVRUtgg2P6g9D0fTtyiqAuW2xYWaJWXKpuiVntSka4CQy+wGLG4zMkYVva3sH/HAgC/MmeJcXp11RSYkHHWB5UQtP4D4E2XBah2bpMUEbotl4rNork8vCKMahQ/oRIvoQjL2yu/oBJLaK7Mg3gI48ylietXoTkqqMEOGe4yLY19qLwaVWLjBkacFDYIdpmLpKiqULQILfWKUyJO3hGTwWdcIr+v6ouvmoDJAI1w7kyLuLwwgpMHWGzfd9MsAGDnkBehfYARTxLLpuPMju21Y5SwalruxTUVn4Qwa1KI6r5QrdEX0yVesX4C0LF1koEzXdbiKGABlyvSv5gue5PEMuSBaqOZl1YDr0/1U7DB5KNJVsoVwisPx1URjzkaIyIitimipLBBMCscmtya59V44VDLhUerhBDWlFUzmFvgqE40OhCgVkGfeZjQPcmSwoULewAA5w+t4tAeDr8ckbBqXXlbVPg0bBIP0abChUwr2oE6UCUax9JVF0UZlnuvRkfqNUOPRp8gpeVUA90mZDGQlVxTr+kYcuMrVjk1ggxWJNtzaMLUmIelonwsvL4TCnIqmSIVGrWqyXJIsnPbovCp2W5wREkhIiKihCgpbBSM5DQ4z+QfmWEMJHtza1nrEwbtK27OgersKxe5rXVkWBhmkIhO3FoU0+WxLk5c2AcAOLOXazfceeAcAOCucS8RTKRLAMpp3IogVkKdlrSIbJh01Uclet27mvU5TO7qS9b79acXJFkFxD27KKd06wWOTVU36ISM4w06QVKZpZxXdy2yq5Gk04sjWJzllG/JBYmtuJigMyvXl4jVpLBIJBEO9SQd26p4lG2j/ApxUthg2JNc+2Z4ejdmj/oScoBXGZIBYFr6Q5QXOkWtErVV23rSbCYvOkEZOgBJTmjPyMs/yyXfnn76VgDA42NH0DrIk8Er900DAA4MzbmkJmFORI0nUL8AjWnIbV0dCAm+nlTGdqHLxk8E+rIvD1ouTFrRz1MX2pznGuIsxKAh97nQY4PEFYeFZmQeJC7XoqoD+lyyJcKoPPtsRZ5730K1Cy0qm+RwXqi0yp0YURli6HRERMS2RZQUNhhmlQnH4VOLmLttEgDQ2yH1Gc77nIDVzGkUqA9qftQAQ4tAbSC/1T70WKhmuL7ke2s+Ac1wHeBnHuftU5mFlngo2pJdOgWQaqKRchISGHKrq4sbyIGkJ+2CfW7gKO8L7zt0TdB0ibr1BVo8ARv25ZJQNyxr2m94TS99VarwwOfQtGR9chVRG+w28k9QREkhIiKihHVJCkQ0CeC3AdwDnnp/DsBTAP4QwBEAxwH8pLV2Zl2jvA5hn3gO47e8BgBw4W7x2ReJoT1vfYLQQCrQVdt5QspKbVNbkhAAXv1cIKFwD9ZQ4DUp49ABkfUrvmtDoL7q2OT2uZP0WjqeULoJFtBMEkXbyhhDqDST5P64SgOUlwnUKnTF10JRg64fi0aWwgZj0hIZmh8l4Aj9PRDswHMJunW8jnEfpDltm/iH9aoPvwXg89baHyeiNoBhAP8CwEPW2l8joo8A+Ai4vuS2gu31MPZNJh2X9h8GACwekoNEaC2USUIq4P8aCUrHkr7/QerLY1IEsdh6nnW/W23nvSQJqEwisD4yy4n8mc9C7ZPDePWgSoYmA0DcAmqgArXJzCYNfhgh71ixyti08ozAj6e3S7JKT/DA2y+2kC1RqQ/3XFr+s7PitP1E2FryL7t6pGpxH828ZLeR9eGK1QciGgfwDkgBWWtt31o7C+ADAD4hzT4B4G+vd5ARERFbh/VICrcBmAbwH4noNQAeAfCLAPZZa6cAwFo7RUR71z/M6xP5yVMAgD0PcxBTb1KCmfZYR275VYrqadsCb0f101e7vw1CrXVZtYmtTfM+P4p1Jk6rBWgS68K5jYZ194PYACUarZdInFm1r9esk6aKkCB099aGX7VN0K7qtxGc11CKAp0LEpcxkACw21awvMSf22fF56FKlMJrAwkCqSsgca2U+kNbdTllPKNJ8nKQAXg9gI9Za18HYAmsKlwWiOjDRPQwET08QO+lT4iIiNgSrEdSOAXglLX2a/L9U+BJ4SwRHRAp4QCAc00nW2sfAPAAAIzTzhuawaEnngcAjL3yXgBAfwehv0O9HL1O73Rnzesh54erp65+xlqQmtKy4PFVa0yIeREpoB48w6M8CRuT4NBOduvTpCVPndoHO98unasSQ5LXSUhQ6HkpuwLJgSrtLcEtRTXeI+xXYFp1SSTkJdJVcZQ6MQQaNu4c7ld5G6qRrOHYlE9J+77AbI1U3EZE4xVLCtbaFwGcJKI7ZNe7AXwPwIMA7pd99wP4zLpGGBERsaVYr/XhnwD4fbE8HAPws+CJ5o+I6EMATgD4iXVe47qHkVwLO/7saQDAYPQOzNwlq85O3nQuNtQ2DByQbJVRp2AVVj7AAKZSNFVhEwuIm3BvVSIAyeLCEscEvG7vaQDA4t4OTg528fEVTXIadFTr10d66mosoROgAvXaCqHzUsiZVB2xGsyJDbVtHdIeOf1fJRznlJTUzapkAgeoYEympeKOnKtWh20iJQDrnBSstY8BuK/h0LvX0++NiuLCRQDAvs+fRH/8ZgDA4q2SLCRL0JkpewY6cg6BipBX3soQBkiFANS4CAXlBCsvTTGQH35iMbPKP4G/WjjqG/fV0F8eB0zoaeizxDjLqLzILlQ89X24CSBBzZ/ABHEfXi0RE2wLNRMt5f6absJKgiQ2VbYy8GFwz7bwpGlTURiFM0maaJKMiIjYpoixD1cB+anT2PMYhziv7GFRPt+RgzS34cWKxDBAnVQMPfgClcIFJjqPSfWK5H5C2BRO9ShUAml5WdrHPpB2X6pdwWO0sK4GXhA/ITChhABZ7dWEqkRmQV4C0fsLJAdPEvp7qd47GX+OCy5VgnQQSAMBuaim1tA5KhlIJ5I0x+YqTkSiMSIiYpsiSgpXA9ai/TePAwD27eD4iKm3pRjsLNskQ4nB++TLNliNw9Xb6eaV+ohUwEkFDoZ8WKJKCr0ENChLKqVVuRJ9GX52Ukrg0lxdoW1SObnaifse3Ke7hyCyERQ2K19L7zNwba49l5RjRcJrm8w7L22n/AlVxElhg0AdjtaxvctzxNIQ69HPPgYA2NN9Hc69VbII7ZGsP4lkO75IQeCUF72dCB8EQbnJQi0SgUgf5ojU82xFNC+9mzX3QnhyMPBJsHJSdQIIfRhKMROVcZh2EPDVFIx1KandkZzW35+bDcSnI/UqRSnxdFUVssF1s8qrsU1UByCqDxERERVESWGDQG3xAhRJgVptJ+tfShTV9ru+eAIre44AAOZfLRmKJ/m8JM9cBGBYWKbJ8uYIukxt9fLdwMVShObE2nio5orgV1QExyq+FNxvQ7eV1Tjs3Es1gRRTvXQSShTSpkBQnCU4oxqSXTVzhm3C00LfBenX/c009gFm20gLUVKIiIgoIUoKG4UB8wDKLaR7dgNS9yE/wdGSl1pp8tNncPCzfO5g+AAAoHcXl0PPl1OkKyIpaEIQkI96DFboNR1xmgi+xOvy2m9plXfBAX6nrejmYb4DWyE3Qag5DTUWdk3gCcAGXgKhtCPXrsZNUEGO23CoEqXVW2sgQUlNkiopOGZ3e0gJQJQUIiIiKoiSwgaBRjiGAIf3AwBsP4dt8+NNF3cA8G7Oa6F4lqMpb/6zUQDAc+O8zXcNUCyzJSJbrPvzu5U58wy80+HD2hFFRXG33lkodCSqomS10FVVfzlBXgd3ZtC+xjOEDL+aMjNbys/A4wkGULFWhOZHN/7qOQAQxDZULTU2kE7C/tV5yRYqguiAto+bc5wUNgiOaJTvZriN/iSrA+3WQd75EpOC6+s7zwAAdt3xWgDA2e+n2g+ef8Blz8BS8VQVdwOToyf7VC3wA26aDILOZEs1UR5omAwq6gR/qXfrNARDbJaUz/Vrlyezkj9GGEdRVT2qWwQTXJP6QPBqgguE2j6FZRVRfYiIiCghSgobhYTnVxpI1GM7RWueqwylF7iUXCEOMS/lLaeOTTu+MwcAmLlzEvkwr2BZWCq9GvlnQnOjbIKoRi8NiIRh62I4bLBaX0J4KCVZ0Y9VZyAE/FzVOQkIvAv9TpOVRQoy/lzXFXn1pWR+rEoj4e02hHyXriHj17oP2ylRaxVRUoiIiCghSgobBDvBpODyzVzYNe0ZdE7zSm/OvAgASHZJRpX+AMXMS5fCSOaXpa8dGExWc5KheUp3udfLy2Yy8Eu6IwnJu0q7moyhh1L1koGbc0mXr6R9r67sgK+dSQWVJAPXtyZVqThF2QxAUWkf8h9hstsgApL3yTVDcQa+DVWrP1kAWu9hG0sKcVLYAFCrDeT8I0r7mieQsHoLl43rdKSGwDmeCMzhfciGufJyPnWWO2lK4iF9IhChQ1O848DCWAY9VhWXA5G7OmGE/ZY8GmvuhSiL5Hqdygtdura+mC6QKwhqUlUh8S+wUwe0OE1IPGrm6UDF8KpTMOlVtZ/gdkMLRrWEXJJbr/7phLGN/BMUUX2IiIgoIUoKGwA76MOemgIAdFc4lqHYPYFcTJK9/axatNVv4ewsir3su5B12JRZnDhVJyDFSzIdALYtBFjCy3KpFJra+4NTHamoK3CQrMQGKoC288lNvKekO6YLamp90hYX2hys/A3PxiHI+GxbFb1kqMDQmGaY5o5781IjrpeWxuvutxpTAQuNiixVxQKrJtWaGskaXK9tyfPVaNTtZ5GMkkJEREQZUVLYINg+mx+VqEpW+7DEaY2LDs+9U9/PJGR7bgy7H+F6C4P9XDUq67Rgjp3gPoTksurROAxAE5+ohBCu/E1/RVcvUpoHnocIkovYdkXMCDwfq0VfqfC6f8lrseI92eioFNaf0HYiMbS6OdJUakMWWolW78242AsXnxHcQ5jDwSVirfAXVHiiJORkklyOa1o208ApkIpE24dbiJPCRkGy/g5u2QMAsGlS8sADgGzJk2k2452tE+cBAGb3BMwb7uR9L0wDAIpxJiMHI15s1z5NhrWDnwD30riXcS2fg7ysZnBgkZzSFFDUZO+v+iCEZGh2iUHKGPNB6pLBuMtkmnCRvAqkKlEvdfkmXYDWwAu9jqxsSKhS9l6UdgFhSz3peBtlb64iqg8RERElRElhg6DJUrInWAUwtx+EzaToiiw6k8+yimEzQm8PB1ANn5/nNosrSDQ/4BCTbMkCeza258fR21U2/pdXQRGlYX34cFMQUYNZsHYfhFqYsxPDDXkhIPSizPy5JQSijJoWLVlfOFf6zVoFdoyxT8ZYh5/j7ApLSQvLHewaXwIADLd4FT89M4GVOVbNaDlMVqk3wZvEka3BsfC5qNSlzz0l2Eztq9tPbVBESSEiIqKEdUkKRPTPAPxv4Ln5O+CycQcAfBJcEO2bAH7GWttf5zivGxSzTCAm/X0o2rKaiUdeIuG41hIWb2Ip4vzfOwwAWN5vcOBvuN3EIxwrMdjDxGR/wnjnHv2LrWEqq0U7Ol6jadVGYM8MEqlUlgptT3k9TDqswVDLmIywz0CC0USvwhvsnFjCzxzhOsVH2+z9+Xvn3g4AeAp7cc9ONve+bpSlsP88eDNOzwyVxk3W15hwCdREEkn7DSX5AijhmAwMqCc/1W0oISiuWFIgooMAfgHAfdbae8BC4U8B+HUAv2GtPQpgBsCHNmKgERERW4P1cgoZgCEiGgAYBjAF4F0A/r4c/wSA/wPAx9Z5nesHusI8fRzt4VcCAFb2ScXVBT5mWgl6kzwfp0wbYOJpQi6LH2S1SiRijww5c5uiZHkoFWGQYTRZGxpSFdiKrS4s2+5MmMrYNyQ+CVFLchKMK3RpVqQiKbxyxzm8Z+RJAIA8Fvxxix9MP0/x+EVOT/et85yXYvrimLOauOdigKRSk8K5SDdJVdbzMlQ5j79sX07hiicFa+1pIvo34MrSKwD+DMAjAGatteovdgrAwXWP8jqEWV1FduoCACAb5WxMGoAT+gx0Znnfzm/NY+7OMT53HwdOmSyoohyI8ACrEY3ZnAWNpGL1923hSb8wIruh4jN/J+fXYIPq1q68XJWgDMOTdbAFYFvlgUwtT+D/nn4nAODFVVaZnpvhytcJWZybZX+NwayoY31C2pNQ9cAPI6x/UdqGYdUu/jocWzAYjTfZhpOBYj3qww4AHwBwK4CbAIwAeF9D08anS0QfJqKHiejhAS6vgEpERMTmYz3qww8BeN5aOw0ARPRpAG8DMElEmUgLhwCcaTrZWvsAgAcAYJx23pDTci4h0+19HC1pJPbBZOR872fv4O3yvgm0luS8CTZJ5kPaHshWKp0b77RYNP0Vq6t14KzjVslwSaiUWiu1030hWekK19p6rEQaqApNK7Q6LS2xuPTcqT144RxLR7smFwEAQy1+QFPTE7AXxUTrJABqJEgpPI66pBOCisAjVLpIl3PYpaW1T9omWI9J8gSAtxDRMHFJ5HcD+B6ALwL4cWlzP4DPrG+IERERW4n1cApfI6JPgc2OOYBHwSv/fwfwSSL6l7Lv4xsx0OsS4iprH2USLdNYhvtegXSFV7qRUxIVuBNY3CUmyeclmnJViMYi9QtumO24VgfS+qg+jQYMkrs6IrDOS3okqCl8pVwLFdIuTJpS3YYxBwobKv/BdYzcw9mzLFXZFYlWHNAaEkA59qE0rqokFCaZDSWWSjyEaadAS8tQRaLximCt/VUAv1rZfQzAm9bT7w0HmRyKWc7E1Dm/gs5OFp1pjn+x+76+jMEY/yDbF9i7b3X/CJ+f+FBfFaFtGIiksKhVm1avwdDXP5QPnf9AWGC2omaE5d0aC6tUU8c7MtR6gjG0CFRzQK4msEpWli/NpdyKSh82IFK1qyK8aZTal3aFKlH51tmPRAsEb8PJQBE9GiMiIkqIsQ9XAeax72FSbO6zb2OPRktA9peP8HFJpGIPvt6d48ujyY7Qn981Qi2ZiFuVU+uldmeubBhcIG002vcr5CNZ384XXFETJTX3UV2KgjgE7TeVdGwmRU3MR3BNJ1GEnpwNcQ5VNSPJ/fNwIdSDUM/YvupDlBQiIiJKiJLCVUJ+6jQAoHueHZtO/+AYRu54KwBg11fYlOkSixrvnecSnzTlA7BoTriCMlfg1tSCIwOrfdSkjTCysCJllLgKbd5UISo8PijncLDkCVHt3wQOVI15IyrciYF1UZFOmgrGqk5fnjQll2RXYdPEp8TbhhKCIk4KVxntrz4BANiHu9CfkD/HAtvKye7mram75JZeuEC8ttWJwgUnBS9yUEClVsDFBO945b0oZXoO1YdKH2VPxkp7Q2WyDxLivNY7GE464b3pue4Y1cZRUrkqAVFkLUzGA0n7euL2nQhCRPUhIiKihCgpXGWYZTY/Zn/5CDIhtwqpdNwfuw0Ar3xO/A0kXr8yr212dKuy8V6AYZ5HWyXxgmu4MGlT3uq5gEgfVd+F0NTn4hHEXyILytepStSySHIq9xFes+pZaYPrqyaS++PVTM3lQCc5LyEnGSjRmC4NYAeXLum3HRAlhYiIiBKipHAtwem0khF6ICt74N+vocImg+cSlGBLbN2c6Fb0YLkM6z5UzYmmQScPU7q51dgnanGSQegoBSYPqzyDIxkBF2mZ5D4JSi2Ikfy9hBJOU2m7aoWq0MEpKT/aUsk4TcdmhltIU4lMrYSqbydESSEiIqKEKClcg0g6HBU4GHbeQLVcBSEfUDUdAg1kfqiyh33Vgh8CVFl/BNfMVIoJzYd8sKFUZSBieCtBmLa+apEI62PWOAvjB1KSZkKLSK19+RgVQCJp8tzQejlssQ1LQlUQJ4UNQNLtwqyublh/NCTFZ4dlh62LxqBwMtCIHviX/BKFWUKVgqpFVdB8Lf3eWES2cqLL5pQE/WuBmdRnSLLBabbchb8mGiYZS7VJsmQuXXtojaZUl/wmN0HR2e2LqD5ERESUECWFDQCNjXl+bwMkBrPIzkutRU80OqIuaOciJnUV7lhPPkobt8gachGT3qmHfPxDwwJZS5oS7CulM3MEYFkcDx2KirYnFatkYknqqDhdwdadopLcuhXdp52Dqxq1lhpRHpsfgBKNxVArrpKIkkJEREQFUVLYANBwF9RmTx9zujH73MvrT/vKwtgHOaYro60TjaFuXo0sDOs+uJW5IaEKN9A+KsES1vfT5IxUIwsD3kOjHkOpILy0Ohy5e2nwIQpjKqqp1kLnpZCP0K824B6qA1A3Z5sSknFOHFtMT9cHsE0QJ4WNQJKgOMDVo5MLFwGsT42gLlsfiq7u8Meagowc6ZZTOalKeG4gLjckPmp8kX2mo4BddEVpmjqp95UUqLWrqg1k6hNKqBZU77MxTDogY5vUh1roOQL1S+63t6uN1m7O/IRtPClE9SEiIqKEKClsAOz8AvJbuE5B645beee3nrji/sw8ZzR2GZybVjxblxpsamuh0zZYlp2IrvvSpuU7WGGTtQr4HA0AABVgSURBVKUB55kY+Do4z8vAq7JRYqkkSEGgDtQkhMDMGkoWTX4bbmwVVwMbJqQJfDo0DN2oF2MK9A6w+tA+JTU4Fhaw3RAlhYiIiBKipLARIAJJ3MLSrbzCjM3djPz4iSvqLhliMmEw7PdRhYhDA2HWlIzUrfphjEBoxmvKz+CuSbVjVFSkgeCavpHfOHqhIY2cIxPDqMdqdarAY4pMU8dBH2jeV/KKDDwaFUromgxY3c0kb3cPS37bUVKIk8JGoDDI5jgL8NIBJgln33QTJlaYbCzOnnt5/Ymbs2mrt6Gtv9yE5r+euuxWMhiFk4gJyra5l1D7NeSJSHVlDtyRq9cpEZhVL8OwXRiEpQRfMP6ayO/UAu8V6RvXx106v8GlWeHyMRrvnxD6QSzv5i8j+5g4puNyIXOJyjI3GKL6EBERUUKUFDYCRQFaZFZw5DSv8jN3dnHhb90OANj9Ja7nkJ88VT+3IWuwFXOmhk6H4rtbIRtiFZKCYGDL7fS88JLhil6N/0ksrCtmW/ZoLGVnbvB1UOLOlXdrIihDNUbVh6CPqhdlmDLOB1LBLWdNEoIP0w5uq2J+tOT78L4UwIB5RizewvEnk89yObvt5LcQJYWIiIgSXlJSIKLfAfB+AOestffIvp0A/hDAEQDHAfyktXZGakr+FoAfAbAM4B9Za7+5OUO/dmDz3C2c2QJzCyMvtjB7Oz/e6XdxbYfdXxGnpGeOoZYkNEmd3pqMMMOYDwdsYYVYC+shuIzGqY99aBxnpRpUSX4ImMlqpGKpQlPTqWm5X0cjNFSxaoxmDPuSMSZBMpbqNUtm14qzU/Uzj796QR5XPZmMj6kolM8Z7tZPvsFxOZLC7wJ4b2XfRwA8ZK09CuAh+Q5wKfqj8u/DAD62McOMiIjYKrykpGCt/TIRHans/gCAd8rnTwD4EoBflv2/Z621AL5KRJNEdMBaO7VRA74WYQc5EonJN8IRdKdXMTrEK/7MK3nuXbppHwDgwFcmkH3lcT6333f9kFgd7E5mvvMhOdBQw7EU51AajD8efBUnIKocC1fjem81c2WDrxMs2L0adQnANpgf13LTrpWBbOIMNEqy79uHbtTePbtySxS0b7BWaOxDa9nWpYptmHTlSonGffqiW2uniGiv7D8I4GTQ7pTsu8EnhT7Q45ebDL/JFimGz7IqYVIxU97Bv9rj729j7FVvAAAc+CITWPb5k64QiRliW/lgVCaatnUvdCpziMkAKwWSQ49CW81IopNESCpqIFCBoBbEJQKWAnJRvSLDojTenKnj0D6BamGYkjdicLFkDZOkDYrrNuZjbJiwHMkqRCPldY/JJIfzLenO8sGh00voj0oMS9E45W4LbLT1oUmjbXy6RPRhsIqBLoabmkRERFwFXOmkcFbVAiI6AEC9c04BOBy0OwSgMZbYWvsAgAcAYJx2XvfTsis3pjAWJI4yw2d5yTItXtrnb00wdzevTgu3sefcxNO70Z3l9udfzXNrvpfPa59pwYhUoKugyTzhFhJ96uhjK2HPNqmrA4ZQzvIMIRUbHI7cfablfaG43VSwdq3M0PzFmzqr6kNoNnUcqI4nr99LKb1aQzUtdVoKU7CphDB8bJZ3Tl/EDpXI5jjRjZb32064UpPkgwDul8/3A/hMsP8fEuMtAOZudD4hIuJGw+WYJP8ATCruJqJTAH4VwK8B+CMi+hCAEwB+Qpr/Cdgc+SzYJPmzmzDmaxJG8igkk+L9MtSqrX4jZ5gQaC9kWLyJl9X523k5m33HKtdtAFx6NSwwt5Cu+NVbqzbZ0OHHeD7AcQpV02GYdbnk8FMeZMgDOD4gjEQMOQrZ51byCklXNQ3q+H21Kz/uxgzMOp5qPAfWMHVW6RS532QAWB1wkDLOx2NwZ2ZhEfZRJoC3c52oy7E+fHCNQ+9uaGsB/Px6B3U9QtUHWuQycDTWBVpleVorPCcDi9Ez/IvszPG+xYNDWDoqLKL8ftszfH5r0f/gNfFKqUScvnxp8AJVxfXAryEk6WpGhzB0uhKWTAUaVYpaGHPgO9CkFvjApsBTsupvEKoClUnHpnULQylo6xIGgyafBcRScSVEj8aIiIgSYuzDBsPMc6gt7RoHui/9eNMeL3VjJw1GzkhuRlERdLXMhwIzmyxqiQ3MgkFSk9BUCKCWdAUIVm+DeqhyqA6otNEQ5+C8C1P2GyhdMyx5X/GbQOG/uDiHUEWojIcCs2mtJF5wL0kO1OIyAunDRUdKv8nAIu3xFxJJIRaXZURJISIiooQoKWwwNClHOnUBaWc/72vXbXW6crmMzaFuX432s9Z5H4akm0/YKvvaAXmniVWrq2flc2MkoxtkeTxNjRp19CZOoamkVEMfVXNimL4tzNsQpqXTdlThJUKitMmT0pGPESVESSEiIqKEKClsEorpaaQTowCApMtpw4sGjiEJdPlqPgIT6vaBExJ/CFTnpnaVVdO2gvahc1KlIlPS9+Oo1XVM6vwBbDMPoKiZGgMno9AaUkszV7WAhP2HfYaJXqv9BufVE702SAn2EmaLbYQ4KWwm5jgrc7qDJwfT5l9+0U5cqjXnXRhoGIUSjUFCkJpInPhzQk/CauxD1QMRCN6HIFkJgoClpEklAMoFbJ3Jk1ANAw/Tp/l8kKrOBMfCyaPh/tz+WqRV8FEnsMDLMXF+ELr14eDaf9o3SFeEYFxYlM6ue8faDUFUHyIiIkqIksImQlN4ZVJXoDh6EwAmF13ikkBlcAlGJBRZTZNkGyRbG4jEoVOPJlmtVnBqkJZNVlcRSslKgn51HNX0bTaxNY/DcIdLqxYmaknK7amoqxkuMpICiaJq3gz3mQbSs0HN0OhHjpxUUSKujSHi04iIiCghSgpbgPzFswCAdkdCHW/ejcGYmBhFxzbBX8IlYpXVMm8FTkjhiq4rbngx3Vch/yz5c8Oy9k0uwY1VnSCrvQyu1EYTvVZsl0wqlrmTUsxBw4rvvjZEPza2DV22q3xEAzHp0rqngE31YUWCMUScFLYQxRmeHFojQzBtKUvmajsQUkkKUsivWH/ASd5g5k+D33Joq1ePPauTjbzEgdegy4KUBi9QkFmZKmK6T3gS1GAISsp5X4GyzwUVvn/HfzaVfAtJ0OrkEExmIYGofZgg6Kl6f2GNB322mXiQpj2LVPJpGiUaIwBE9SEiIqKCKClsIeyAjfzm6WPoFEd43y1S+twC+VBZH3DmvKCPUkhx1avPlNWQEEkemCcv5chn6qu1j1Gwjfuc5KHXboigrEY/hp+bVISQAK3WfSiFdzcQo677BvI0lLg0HVs0RJYRJYWIiIgSoqRwFWDzHMUzzwMAusltAICVmyd8HAQq5FwOJLJKG/J6e5OPf7XmZBL0RUWZJCDj18hS6fcKgeF1dZ/3QGMrkoJKDkQvBbLBCh7GcbiBlMdP7r+ylFQdW3gPjlcJpYkKT0LGumS7KLZPncjLQZwUrha0YOkUp7fsjHZhU86gklcEOJuQF41D34XGStFyToMo7/uzrg93nnNRJv/yhSHTlb5csZZgHJdKCV8aY7VYS0PbsDJ24/kVz8okDya5piAvo/4SQjQu58AC52Gs5dfc5ojqQ0RERAlRUrjKKGbnAADZqWl0DWd27u3m2hH9cV4mKRDnNUM0kiCFmYrXabP04M51/gSMEnFogpW/6qcQmBCrKkLJ76BK7Nm6VNAUwk153fxZCquu7suDgrFhsJaOrRLnkAT963jSlQHs4hIi6oiSQkRERAlRUrhGUFycQdpmwqCjO4mL5DA5F7ghAlxyPqkQgiFfZkvNyyELbsWl+irclKKtUUe/jH1NTkkN8QghahJAkKTVjQt1iSjt2VppOH9x30e2wgeTuWUUK6v1AURESSEiIqKMKClcI7C9HuzcPAAg1SK1AylNv2cElvhPlRuZxzuAkeVXLQFFmFhVJYrAWtGUdLUppXp1ZS5xBWs5GYX3QvVjbhUf+P4aox5DUyTKTlckFsSkQD1ak4I8ELW8Cj6SM12VRrPz3gIUUUKcFK4hKOmYZvxnoYzfhvY0QIZVid4Ofsv7gZDnip7kdYk8GQRfVCS/RJh02K5KIJaIw1BzqYY964udB2J+QAg2xjfouQ2TjLuHBhXEmRrD0OmaRyaQLfOgOie4aE8uxXsi6ojqQ0RERAmXUzbudwC8H8A5a+09su9fA/hRAH0AzwH4WWvtrBz7KIAPgVN//IK19gubNPYbFsX5CwCATCQGtDK0pqXy1IAdnGh3G31Zhn1KNyrXV0CDqQ8opSdsCpNujFOo4FJVmEomzIp5sDFKEqjFLZSK3KoZse/Z06qKkgwCByyJaUhF3WgtFa6IbHHilPQfIx7WwuVICr8L4L2VfX8O4B5r7b0AngbwUQAgolcB+CkAd8s5/56IGnzSIiIirlVcTi3JLxPRkcq+Pwu+fhXAj8vnDwD4pLW2B+B5InoWwJsAfGVDRrvNoMlZMiJg5wQAoHWBHW7SpQGyPezktLLb/xmLrsQ6VCIhbRZEUDaZChvIxKrZr5Q2rRS66Y+Xvuf1NmHOB5dBenCJVTtvkDYApNK3yzwdHpOcCa1FFjGGTi7AHDvBl48uzS+JjSAafw7AH8rng+BJQnFK9kWsA/nZaWQpC1xmJydnQZYgW2AGbli8HLPJDL0xftNyni9gxZfBmuAlDdWHMMMRUCqckvbK4yh5F+q+Jn+FXBO7+MYuN2JowWiwPuhkllbJxQBJHlgTnEXCusmgc54H3nr+RQB+co24PKxrUiCiXwEnB/993dXQrHEZIKIPA/gwAHQxvJ5hREREbCCueFIgovvBBOS7pQQ9wJLB4aDZIQBnms631j4A4AEAGKedkfW5FEyB/NRpAECW7wMAFAd3Q+VvLZTanTZIV/lPqnETuZSuN60yIQmgxCi5FTq3rpyaEnZh1GRVfUhy1KZ9n/wl8DIMJAW/r9ye+y13Fh7TPpKBDQrFcoN0JUfrNJsZi9NTfO9RVbgiXJFJkojeC+CXAfyYtXY5OPQggJ8iog4R3QrgKICvr3+YERERW4XLMUn+AYB3AthNRKcA/CrY2tAB8OfEq8pXrbX/2Fr7OBH9EYDvgdWKn7fWRrexDYTqx+lgADokUsOoREskQLbMjztd5RU0H2aJYTCSOO9GlRjClG5lUtGvyCHWMkNWpYeSQ1HNkShkOWUT5kKoBGvYjNw5JalBJIQk521rahb5CyebBxjxsnA51ocPNuz++CXa/ysA/2o9g4p4aRQXLiKVFym9matb52MdQLM3OYuAMPHLBkWnnNEpzJRczpdYickOEGZr0vMSl9FJ28jXsL6jQDMsA77iNoUqQ7XCdGHr6klu3L7swgqfNhXJxI1C9GiMiIgoIcY+XMcoZmYAALSwAABo3XozBjexP4OFrsLS2Fhfuk2WWZs2pF5DZaVHoA4UQWXsBvNmVRUp1X0YeDOlSi9JX9UC66USJTdV+kio5r1IBsiW2WaZXGBPxXw1hkFvFKKkEBERUUKUFG4AqJde8cwxtOb3AgDy2w4AAMy41rUnpH1eyou2mDKN9RWWXLg0OV3fmQADHkCL34bSgyaJrSZwpcLWIhfTvgHkXNOS2I2MfJq5KoytRU4m/QLpDBu9zMxs83kRV4woKURERJQQJYUbDMVZThmf9djVNzvIlon+nhH0JyRPg6uMRHUzo7UursCbLr10UHVoClOdVVOskxFLAcpmS+0jWxm4/rUsfNKXzhynAJA4Z5HWaZhfRDHNkaQxUcrGI04KNyg0YQtk2x4fR/sAqxb9A+PcppPUfACSwoDEB8C90Pq9KEC9XPbJzFEUgLzQVsk+NTEaC1cFVyYMay1gjD/X7ZPjWpgleNmju+vWIqoPERERJZC9BpJNENE0gCUA56/2WADsRhxHiDiOMq7ncdxird3zUo2uiUkBAIjoYWvtfXEccRxxHFd3HFF9iIiIKCFOChERESVcS5PCA1d7AII4jjLiOMq44cdxzXAKERER1wauJUkhIiLiGsA1MSkQ0XuJ6CkiepaIPrJF1zxMRF8koieI6HEi+kXZv5OI/pyInpHtji0aT0pEjxLR5+T7rUT0NRnHHxJRewvGMElEnyKiJ+W5vPVqPA8i+mfyN/kuEf0BEXW36nkQ0e8Q0Tki+m6wr/EZEOP/kt/tt4no9Zs8jn8tf5tvE9F/I6LJ4NhHZRxPEdEPr+faV31SkLoQ/w7A+wC8CsAHpX7EZiMH8M+ttXcBeAuAn5frfgTAQ9baowAeku9bgV8E8ETw/dcB/IaMYwZcYGez8VsAPm+tvRPAa2Q8W/o8iOgggF8AcJ8UH0rBtUS26nn8Lup1TtZ6Bu8Dpxw8Ck5C/LFNHsfW1Fux1l7VfwDeCuALwfePAvjoVRjHZwC8B8BTAA7IvgMAntqCax8C/9jeBeBz4CwF5wFkTc9ok8YwDuB5CM8U7N/S5wEuCXASwE6wG/7nAPzwVj4PAEcAfPelngGA/wfAB5vabcY4Ksf+DoDfl8+ldwbAFwC89Uqve9UlBfgfgWLLa0VIsZvXAfgagH3W2ikAkO3eLRjCbwL4JfhkZLsAzFprNZXJVjyT2wBMA/iPosb8NhGNYIufh7X2NIB/A+AEgCkAcwAewdY/jxBrPYOr+dv9OQB/uhnjuBYmhcuuFbEpFycaBfBfAfxTa+38Vl03uL7W6Xwk3N3QdLOfSQbg9QA+Zq19HdjtfKtUJwfR1z8A4FYANwEYAYvpVVwLZrOr8ttdT72Vy8G1MClcdq2IjQYRtcATwu9baz8tu88S0QE5fgDAuU0extsB/BgRHQfwSbAK8ZsAJolIo1i34pmcAnDKWvs1+f4p8CSx1c/jhwA8b62dttYOAHwawNuw9c8jxFrPYMt/u0G9lZ+2oits9DiuhUnhGwCOCrvcBhMmD272RYlz038cwBPW2n8bHHoQwP3y+X4w17BpsNZ+1Fp7yFp7BHzvf2mt/WkAX4Sv0bkV43gRwEkiukN2vRucqn9LnwdYbXgLEQ3L30jHsaXPo4K1nsGDAP6hWCHeAmBO1YzNwJbVW9lM0uhlECo/AmZTnwPwK1t0ze8Di1jfBvCY/PsRsD7/EIBnZLtzC5/DOwF8Tj7fJn/YZwH8FwCdLbj+awE8LM/kjwHsuBrPA8D/CeBJAN8F8J/ANUa25HkA+AMwlzEAr8AfWusZgMX2fye/2++ALSabOY5nwdyB/l7/Q9D+V2QcTwF433quHT0aIyIiSrgW1IeIiIhrCHFSiIiIKCFOChERESXESSEiIqKEOClERESUECeFiIiIEuKkEBER8f8PBYwWCqNgFIwCFAAA4cFQl93ibpkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(plt.imread(o10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'frey_faces': {'url': 'https://cs.nyu.edu/~roweis/data/frey_rawface.mat',\n",
+       "  'load_function': <function src.data.datasets.load_frey_faces(return_X_y=False)>},\n",
+       " 'f-mnist': {'url_list': [{'url': 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz',\n",
+       "    'hash_type': 'md5',\n",
+       "    'hash_value': '8d4fb7e6c68d591d4c3dfef9ec88bf0d',\n",
+       "    'name': 'training_data'},\n",
+       "   {'url': 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz',\n",
+       "    'hash_type': 'md5',\n",
+       "    'hash_value': '25c81989df183df01b3e8a0aad5dffbe',\n",
+       "    'name': 'training_labels'},\n",
+       "   {'url': 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz',\n",
+       "    'hash_type': 'md5',\n",
+       "    'hash_value': 'bef4ecab320f06d8554ea6380940ec79',\n",
+       "    'name': 'test_data'},\n",
+       "   {'url': 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz',\n",
+       "    'hash_type': 'md5',\n",
+       "    'hash_value': 'bb300cfdad3c16e7a12a480ee83cd310',\n",
+       "    'name': 'test_labels'}],\n",
+       "  'load_function': <function src.data.datasets.load_fmnist(kind='train', return_X_y=False)>},\n",
+       " 'coil-20': {'url': 'http://www.cs.columbia.edu/CAVE/databases/SLAM_coil-20_coil-100/coil-20/coil-20-proc.tar.gz',\n",
+       "  'hash_type': 'sha1',\n",
+       "  'hash_value': 'e5d518fa9ef1d81aef7dfa24b398e4a509b2ffd5',\n",
+       "  'load_function': <function src.data.datasets.load_coil_20()>},\n",
+       " 'coil-100': {'url': 'http://www.cs.columbia.edu/CAVE/databases/SLAM_coil-20_coil-100/coil-100/coil-100.tar.gz',\n",
+       "  'hash_type': 'sha1',\n",
+       "  'hash_value': 'b58920394780e1c224a39004e74bd3574fbed85a',\n",
+       "  'load_function': <function src.data.datasets.load_coil_100()>}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data3p.datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_frey_faces(return_X_y=False):\n",
+    "    '''\n",
+    "    Load the Frey Faces dataset\n",
+    "        Dataset comes pre-split into training and test data.\n",
+    "        Indicates which dataset to load\n",
+    "\n",
+    "    '''\n",
+    "    dset = Bunch()\n",
+    "    if return_X_y:\n",
+    "        return dset.data, dset.target\n",
+    "    else:\n",
+    "        return dset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.paths import data_path\n",
+    "from src.data.datasets import fetch, fetch_and_unpack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/frey_rawface.mat')"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "frey_file = fetch('frey_faces')\n",
+    "frey_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import src"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True,\n",
+       " PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/frey_rawface.mat'),\n",
+       " '32c4bc7a947721c46df32d4f4973f31daf5d3946')"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "src.data.utils.fetch_file(**data3p.datasets['frey_faces'], hash_type='sha1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(200,\n",
+       " PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/frey_rawface.mat'),\n",
+       " '32c4bc7a947721c46df32d4f4973f31daf5d3946')"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "src.data.utils.fetch_files(**data3p.datasets['frey_faces'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.io import loadmat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_rows, img_cols = 28, 20\n",
+    "ff = loadmat(frey_file, squeeze_me=True, struct_as_record=False)\n",
+    "ff = ff[\"ff\"].T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1965, 560)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ff.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ff = data3p.load_frey_faces()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1965, 560)"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ff.data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f6e4a9f6908>"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMAAAAD8CAYAAAAhZKvRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAE/tJREFUeJztnWuMnOV1x//nfee29/WuL/iGL9hcTJBNQ2gk0sYUcUuTQtoSBamppaCQD0FppX4IQq2C1A9FatM0VDQNpBau1JAgpShUQlxkUVBDm8bcYgOmULPgtdfeXa/Xe5ndubxz+mFn6db2c57xzu7MuM//J612d84873vmnfnPO3POec8RVQUhoRI12wFCmgkFQIKGAiBBQwGQoKEASNBQACRoKAASNBQACRoKgARNqpE7S2c7NNve57SXuu2sdCZXdtra46K5VmzXkJLE3nfk3jcAdEUlp833LiNe7y5eFIuvNHg332/a4+HYaZudOY1Scdp7YOsSgIjcBuB7AGIAP1TVh6z7Z9v7sPOmP3LaB2+2D9bmbSedtp19x8y1ac8LfGV6yrRvyQ6b9t1tx522rNgSyElD34caSknt427x2df/0LR3P9LjtL3284dr2seiPwKJSAzgEQC3A9gB4G4R2bHY7RHSDOr5DnA9gPdV9YiqFgH8GMAdS+MWIY2hHgGsB3B0wf+D1dv+DyJyr4gcEJEDpYL9MYOQRlOPAM73BeOcD/Gq+qiqXqeq16WznXXsjpClpx4BDALYuOD/DQDc3wQJaUHqEcAvAWwXkS0ikgHwZQBPL41bhDSGRcffVLUsIvcBeA5zYdC9qvqWtSbJAhOb3LFbxO5YOgCUEvfaYsV+KD2ZGdN+Vc4Oo25Oj5l2X6jTYlbtHIOPuI48QlqM5wP+MKZvfT3b39JrH/PhXK/TpjU+HXUFoFX1GQDP1LMNQpoJSyFI0FAAJGgoABI0FAAJGgqABA0FQIKmoXW4mYkE615wx3bza1eY6wvr3O4masfCr8rZSepdnnLnnNjbrxj7jzxr62W8YucRrEh8e2SXoPtyDPXmCSzf+7PT5trp9yectrhQMdfOwzMACRoKgAQNBUCChgIgQUMBkKChAEjQtFQ7Ak/jBlSMiJ2vHHqk3G3aTyRZe+ceDhfWOm0dkd2yZXvGDsFujO2Q3ttFO3w8UFrltBUqaXPtpsyIae+OZk37jsykabeYLtvPiSTGC6bGwS88A5CgoQBI0FAAJGgoABI0FAAJGgqABA0FQIKmsXmApIJo2t2eJJ5xt04HgEzKHfc9U8yZax9+80bTXp641bRHefu9QtPuuHPXRnfZLgDctfV1035d+wem/e+O2Y/t4HsbnLYVr9p5gMyEHU8/s80+Lqld46b9L6/5qdN2bNrd/RkA2oaM/EmptlYzPAOQoKEASNBQACRoKAASNBQACRoKgAQNBUCCpt4pkQMAJgEkAMqqep29QoGyO5bvmUSKSNwx6bde2mauXfG+ve32YXvn6Um77j2/zp2HGL/Mrtd/Etea9rVX2LH0t17fbNpXHHa3Nsl64vyebjPQ2F4/Nd5m2r916Hedtsv6Rs21+S3u/IYetvMb8yxFIuxGVbU9JaRF4UcgEjT1CkABPC8ir4rIvUvhECGNpN6PQDeo6nERWQ3gBRE5rKovL7xDVRj3AkAu7qpzd4QsLXWdAVT1ePX3MICnMDc8++z7fDwmNRPbX4gIaTSLFoCIdIhI1/zfAG4BcGipHCOkEdTzEWgNgKdkrvNxCsCPVPXZJfGKkAZRz5jUIwB2XtCaUgnJ0Am3Pb7UXH9ixF0fHnseyalr7Xj1KbXbeOeGfXXzbltkT3/Fqk67Dfjvd9nXA/yFp59SbLQlKvTYgX6NfK3d7eOabrMf/PS0O3+yY7P7tQIAr592f6SWMtujE+KFAiBBQwGQoKEASNBQACRoKAASNI1ti6KAlt1lx6UuO6QWGaW3pZV2OfMlL9phzhWvnzLtPgrr3O3Xj96UMdde0WO3R++J7Ax621a77Ur2FXcJSm7MDlNmDh017bq237RPbrdbmxw3Orp0xXYJenGDu42OjtjP9zw8A5CgoQBI0FAAJGgoABI0FAAJGgqABA0FQIKmsXkAEUjWPfqyss6O+8aRu8R1zUt23LfQ7SnrHRkzzcnWdaZ97EpjpOcWu9x5MN9r2gtqx+rvufwV0/7Y5Z8zrPZx69xot5vxTZdNMvZxj/Pu3E6nJw9w6hp3fqR8uLb3dp4BSNBQACRoKAASNBQACRoKgAQNBUCChgIgQdPQPIBEEaI2dxuM/hVT5vqk4o4pn9xt19xHU/ZDnfjW5aa9krPbbOTWumvyc8Z411pIeWL1X+i0+5G98tuXOW3vjKwx147N2Mc1GbUTAVt2DJn2P730X52232iz1/7g1s84bfpcbcecZwASNBQACRoKgAQNBUCChgIgQUMBkKChAEjQePMAIrIXwOcBDKvqJ6q39QH4CYDNAAYAfElVT/v3FgOr3H1k+try9nLreoBOO4cwmu8w7ZnYjht3Z+3a9M50wWkbOOPuXwMAmzvq60nU5Wlh/vmVbzptn+q1+/acKNj237r+bdP+mZz9ssiJ+yWYgt0P6Svb/tNp+9ucfQ3GPLWcAR4HcNtZt90PYL+qbgewv/o/IRcdXgFUh96dfbnUHQD2Vf/eB+DOJfaLkIaw2O8Aa1R1CACqv1cvnUuENI5l/xIsIveKyAEROVBMZpZ7d4RcEIsVwEkRWQsA1d/O7q4ck0pamcUK4GkAe6p/7wHws6Vxh5DG4hWAiDwB4N8BXCEigyJyD4CHANwsIu8BuLn6PyEXHd48gKre7TDddKE7K/SnceQPLnHat8qAuT4Xe+aNGly+ws4xdKftOH9H7I7zA8BosfOCfZpnfXbctMdiv08V1Z6rMJa4fbsia9fc39r5lmmfrNjXC1Q8vkXGY5tRY74rgPbIbY8841v/936EBAwFQIKGAiBBQwGQoKEASNBQACRoGtoWRVOKwmpjTGrFbv9xpujOJHf5wpgpO4y5KWeXJGcjOwRbqLgP5fSsHSp8cuBa03542h06BoBCYj+NvRl3CcqVnjDoqsgeP7spZYcbz1TsdjLvFd328cQ93hUAphJ3i52KetrhV+EZgAQNBUCChgIgQUMBkKChAEjQUAAkaCgAEjQNzQNERUH7Ufcuy9tsPZYSO09gkYvteHaSs/fdFdl5hrGiu+1KuWz7XXnRbj3y83XuVjIA0H/QjsXHe5wX7HnzHzsz9bVsebto+35wdoPT9l+e/MearLslfVLjezvPACRoKAASNBQACRoKgAQNBUCChgIgQUMBkKBpaB6gkgIK/e7676mCPXJTxB3vTjz13/nSCtNu1cwDQAX29scK7U5bMui2AUD3h3aOothtP02dg3aO4vhL7nj6VV991lx7pGz7nha7rfwxz3F/c2Kj03Zyxr4eYLrsvs7Cuj5jITwDkKChAEjQUAAkaCgAEjQUAAkaCoAEDQVAgmaxY1IfBPA1ACPVuz2gqs949xYrkh53zLucLF6PM5W0aY+MHAIAvDexyrQPZ+z25ytz7jGth1fabb4/+oJ9vUB61Pb9g99x98cBgG2f/NBpu7X9jLn2pRk7D3C8bMf5R8t2LL/NaHmf9VzDMWv0Q1rKvkCP49wxqQDwXVXdVf3xv/gJaUEWOyaVkP8X1PMd4D4R+ZWI7BUR+zxISIuyWAF8H8BlAHYBGALwHdcdF45JTaZqG19PSKNYlABU9aSqJqpaAfAYgOuN+348JjXudF84TkgzWJQA5mcEV/kigENL4w4hjaWWMOgTAHYDWCkigwC+DWC3iOwCoAAGAHx9GX0kZNlY7JjUf1jMzuJ0gr417l4uxbLtjnU9gA/fyuFJO84/k7PzDBbpnKcnkafHfjJt5wlWXzli2n+9f8BpO1S0953x1PuPeOL8ec8YVYv2lJ0/mSq5rx9RzgcgxA8FQIKGAiBBQwGQoKEASNBQACRoGtoWRQTIpNxhtfys3RYliuyRm569m9ZS0T4UJU+L82LBHSZNznhCqGlPe/Oy7fvoaTsU+XJqm9N2otBtru2M7fGyJbWPi689STpyvx4yhg0AJgruMnBfm5x5eAYgQUMBkKChAEjQUAAkaCgAEjQUAAkaCoAETUPzAEkS4dQZ91VhcWzHwysVt159pdKJp+VKueDJA5zx5Chm3NuPPemLROw7VFbZZcEo2rH48Xyb0/b8h1ebayVt+9bTmzftvtzNll53v4WiJ4ewtWfUaXvX01JlHp4BSNBQACRoKAASNBQACRoKgAQNBUCChgIgQdPQPEA8HqHvX9zttodvdrfKBoB0m9uuRo4AsHMIAKCzdiw9nrbXi1Gzn560a9Pb37bt5Q77acqO2zmQqOy+HqGn335cJbtbDCb77PxIfKndDnMo7b4eIV+wW6p8essHTtuLEfMAhHihAEjQUAAkaCgAEjQUAAkaCoAEDQVAgqaW+QAbAfwjgEsAVAA8qqrfE5E+AD8BsBlzMwK+pKqnvXu0Qt6Ttjuac+cBfPX+UbT41uoAkJqyt9/z3+7tn9pp18TPbrPzH7lOuzePGr2WAKAr516fzNgjVtf9jR3nP/Ep97UGAFDZavs2W3I/5+Nj9kShnVe7x7+2R/Yxm6eWM0AZwJ+o6lUAPg3gGyKyA8D9APar6nYA+6v/E3JRUcuY1CFVfa369ySAdwCsB3AHgH3Vu+0DcOdyOUnIcnFB3wFEZDOAawH8AsAaVR0C5kQCYPVSO0fIclOzAESkE8BPAfyxqrrnHJ277uMxqeUCx6SS1qImAYhIGnMv/n9S1X+u3nxyflpk9ffw+dYuHJOaynJMKmktvAIQEcHcULx3VPWvF5ieBrCn+vceAD9bevcIWV5qKYe+AcBXABwUkTeqtz0A4CEAT4rIPQA+AnCXb0OXrh/GI3/+sNP+ZwP29+h3Dm9wGz0tVTRrh+N8dB+xt5+/xB3f7X/T3nZq1m6fXknZ9iRtl1PrjNv3bJe9dmKTaUZ62j4uE7N2SbOvLb3FNRl3W5Q2qa0cupYxqf8Gd/T+ppr2QkiLwkwwCRoKgAQNBUCChgIgQUMBkKChAEjQNLQtShoVrIrdrb6/uXG/uf6b//FVp63caZcce6dmeqqlT11r30GMiubuD2zfPN3Rkcl79q22vZxzv89Nbva0ZNk8a9qjIbucWo7Z9lKnOz+zapNdXb8+drfYSUtt7+08A5CgoQBI0FAAJGgoABI0FAAJGgqABA0FQIKmoXkAEUFO3HHnT2ROmevLHe6AuXquB4im7fbnvjxAJWsH66N+dyLg+E12PX8062npUrDtsacDSFR0H/NSr32dhG90bbnPbukSn/Y89qL7sd2+4W1733D7XmsTHJ4BSNBQACRoKAASNBQACRoKgAQNBUCChgIgQdPQPEBRBUeNkZ1bU3Yvl9Qqd216ecSuO68XSey6+cqU+3HFU3YOIjfqGaN6wo5qp42+PwBQNg5NVLJ9m+m1fUt3uq/vAIBy3t6+Zty+39J10Fy7FPAMQIKGAiBBQwGQoKEASNBQACRoKAASNBQACZp6xqQ+COBrAEaqd31AVZ+xtjVS6sLfD9/otP9e/wHTl97uvNN26oRnXGebp/mOx2yOdwWAlDuenXTYNfczsf0+VMnY9rK7Pc6cfZ37goGObrvvz2pjxCoAjE3YU3+sOD8AIOM+8D8c/qy59AdGs6cPi7XNa6klETY/JvU1EekC8KqIvFC1fVdV/6qmPRHSgtQyIGMIwPw0yEkRmR+TSshFTz1jUgHgPhH5lYjsFZEVjjUfT4mcHbdPt4Q0mnrGpH4fwGUAdmHuDPGd861bOCUy17u89TqEXCiLHpOqqidVNVHVCoDHAFy/fG4Ssjwsekzq/IzgKl8EcGjp3SNkealnTOrdIrILcx0oBgB83behfDmN14bd359/MXSpub5cNkpr62x/7nsrkJJnFGnaiKPanUGALjvUmKy3w6j93dOmvTPjLllOR/a2R/N2mLM043lwkaddTca9/5dfudpeazwnU5PP235VqWdMqhnzJ+RigJlgEjQUAAkaCoAEDQVAgoYCIEFDAZCgaWhbFJ1Iobx/pdMe211RMPlJd7xcPG28U5N2e46KUc4M2DFnALC6pqhn2ziVNc06a+97OGfXQ58wyrHFyl8AkJSnTnzSfgl5q8h73L7ltp4x13Yapdon2+227fPwDECChgIgQUMBkKChAEjQUAAkaCgAEjQUAAkaUa11oOQS7ExkBMCHC25aCWC0YQ5cGK3qW6v6BbSWb5tUdZXvTg0VwDk7Fzmgqtc1zQGDVvWtVf0CWts3F/wIRIKGAiBB02wBPNrk/Vu0qm+t6hfQ2r6dl6Z+ByCk2TT7DEBIU2mKAETkNhF5V0TeF5H7m+GDCxEZEJGDIvKGiNjtqpffl70iMiwihxbc1iciL4jIe9Xf521J2STfHhSRY9Vj94aIfK4Zvl0IDReAiMQAHgFwO4AdmOsvtKPRfni4UVV3tUBI73EAt5112/0A9qvqdgD7q/83g8dxrm/AXMfwXdWflm+d04wzwPUA3lfVI6paBPBjAHc0wY+WR1VfBjB21s13ANhX/XsfgDsb6lQVh28XHc0QwHoARxf8P4jWareuAJ4XkVdF5N5mO3Me1lRb1s+3rl/dZH/OxtsxvJVohgDOd5VcK4WiblDVX8PcR7RviMhvNtuhi4iaOoa3Es0QwCCAjQv+3wDgeBP8OC+qerz6exjAU2i9rtcn5xsTV38PN9mfj7kYO4Y3QwC/BLBdRLaISAbAlwE83QQ/zkFEOqpjoCAiHQBuQet1vX4awJ7q33sA1DYMqwFcjB3DG9oVAgBUtSwi9wF4DkAMYK+qvtVoPxysAfDUXEd4pAD8SFWfbZYzIvIEgN0AVorIIIBvA3gIwJMicg+AjwDc1UK+7b7QjuHNhplgEjTMBJOgoQBI0FAAJGgoABI0FAAJGgqABA0FQIKGAiBB8z8Fj5dYg7/7jAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(ff.data[0].reshape(28,20))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/home/ava00088/src/devel/dimension_reduction/data/interim/mnist/train-labels-idx1-ubyte'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-55-9e3e6a811e73>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mxx\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdata3p\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_dataset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'mnist'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/src/devel/dimension_reduction/src/data/datasets.py\u001b[0m in \u001b[0;36mload_dataset\u001b[0;34m(dataset_name, return_X_y, **kwargs)\u001b[0m\n\u001b[1;32m    191\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Unknown Dataset: {dataset_name}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    192\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 193\u001b[0;31m     \u001b[0mdset\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdatasets\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mdataset_name\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'load_function'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    194\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    195\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mreturn_X_y\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/src/devel/dimension_reduction/src/data/datasets.py\u001b[0m in \u001b[0;36mload_mnist\u001b[0;34m(kind, variant, return_X_y)\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    164\u001b[0m     \u001b[0mlabel_path\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minterim_data_path\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mvariant\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;34mf\"{kind}-labels-idx1-ubyte\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 165\u001b[0;31m     \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlabel_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'rb'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mfd\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    166\u001b[0m         \u001b[0mdset\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'target'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrombuffer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0muint8\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moffset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m8\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    167\u001b[0m     \u001b[0mdata_path\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minterim_data_path\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mvariant\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;34mf\"{kind}-images-idx3-ubyte\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/home/ava00088/src/devel/dimension_reduction/data/interim/mnist/train-labels-idx1-ubyte'"
+     ]
+    }
+   ],
+   "source": [
+    "xx = data3p.load_dataset('mnist')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True,\n",
+       " [(True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/train-images-idx3-ubyte.gz'),\n",
+       "   '95978b76b6897f6ca69a25145d01716efb615989'),\n",
+       "  (True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/train-labels-idx1-ubyte.gz'),\n",
+       "   '09814cfef5a041118ceace42f8dae995319d331a'),\n",
+       "  (True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/t10k-images-idx3-ubyte.gz'),\n",
+       "   '5edda96c6d8c36ff915115a0e8136d370a021576'),\n",
+       "  (True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/t10k-labels-idx1-ubyte.gz'),\n",
+       "   '9caad14e1aff9adac77d3744963212d36af15bee')])"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "src.data.utils.fetch_files(**data3p.datasets['mnist'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/ava00088/src/devel/dimension_reduction/data/interim/mnist')"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data3p.fetch_and_unpack('mnist')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True,\n",
+       " [(True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/train-images-idx3-ubyte.gz'),\n",
+       "   '95978b76b6897f6ca69a25145d01716efb615989'),\n",
+       "  (True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/train-labels-idx1-ubyte.gz'),\n",
+       "   '09814cfef5a041118ceace42f8dae995319d331a'),\n",
+       "  (True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/t10k-images-idx3-ubyte.gz'),\n",
+       "   '5edda96c6d8c36ff915115a0e8136d370a021576'),\n",
+       "  (True,\n",
+       "   PosixPath('/home/ava00088/src/devel/dimension_reduction/data/raw/t10k-labels-idx1-ubyte.gz'),\n",
+       "   '9caad14e1aff9adac77d3744963212d36af15bee')])"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "src.data.utils.fetch_files(**data3p.datasets['mnist'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xx = data3p.load_dataset('mnist')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(60000, 784)"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "xx.data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:dimension_reduction]",
+   "language": "python",
+   "name": "conda-env-dimension_reduction-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/data/datasets.json
+++ b/src/data/datasets.json
@@ -1,0 +1,85 @@
+{
+    "coil-100": {
+        "hash_type": "sha1",
+        "hash_value": "b58920394780e1c224a39004e74bd3574fbed85a",
+        "load_function_name": "load_coil_100",
+        "load_function_options": {},
+        "url": "http://www.cs.columbia.edu/CAVE/databases/SLAM_coil-20_coil-100/coil-100/coil-100.tar.gz"
+    },
+    "coil-20": {
+        "hash_type": "sha1",
+        "hash_value": "e5d518fa9ef1d81aef7dfa24b398e4a509b2ffd5",
+        "load_function_name": "load_coil_20",
+        "load_function_options": {},
+        "url": "http://www.cs.columbia.edu/CAVE/databases/SLAM_coil-20_coil-100/coil-20/coil-20-proc.tar.gz"
+    },
+    "f-mnist": {
+        "load_function_name": "load_mnist",
+        "load_function_options": {
+            "variant": "f-mnist"
+        },
+        "url_list": [
+            {
+                "hash_type": "md5",
+                "hash_value": "8d4fb7e6c68d591d4c3dfef9ec88bf0d",
+                "name": "training_data",
+                "url": "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz"
+            },
+            {
+                "hash_type": "md5",
+                "hash_value": "25c81989df183df01b3e8a0aad5dffbe",
+                "name": "training_labels",
+                "url": "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz"
+            },
+            {
+                "hash_type": "md5",
+                "hash_value": "bef4ecab320f06d8554ea6380940ec79",
+                "name": "test_data",
+                "url": "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz"
+            },
+            {
+                "hash_type": "md5",
+                "hash_value": "bb300cfdad3c16e7a12a480ee83cd310",
+                "name": "test_labels",
+                "url": "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz"
+            }
+        ]
+    },
+    "frey-faces": {
+        "hash_type": "sha1",
+        "hash_value": "32c4bc7a947721c46df32d4f4973f31daf5d3946",
+        "load_function_name": "load_frey_faces",
+        "load_function_options": {},
+        "url": "https://cs.nyu.edu/~roweis/data/frey_rawface.mat"
+    },
+    "mnist": {
+        "load_function_name": "load_mnist",
+        "load_function_options": {},
+        "url_list": [
+            {
+                "hash_type": "sha1",
+                "hash_value": "95978b76b6897f6ca69a25145d01716efb615989",
+                "name": "training_data",
+                "url": "http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz"
+            },
+            {
+                "hash_type": "sha1",
+                "hash_value": "09814cfef5a041118ceace42f8dae995319d331a",
+                "name": "training_labels",
+                "url": "http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz"
+            },
+            {
+                "hash_type": "sha1",
+                "hash_value": "9caad14e1aff9adac77d3744963212d36af15bee",
+                "name": "test_labels",
+                "url": "http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz"
+            },
+            {
+                "hash_type": "sha1",
+                "hash_value": "5edda96c6d8c36ff915115a0e8136d370a021576",
+                "name": "test_data",
+                "url": "http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz"
+            }
+        ]
+    }
+}

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -19,7 +19,7 @@ _MODULE = sys.modules[__name__]
 _MODULE_DIR = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 logger = logging.getLogger(__name__)
 
-jlmem = Memory(cachedir=str(interim_data_path), verbose=1000)
+jlmem = Memory(cachedir=str(interim_data_path))
 
 @jlmem.cache
 def load_coil_20():

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -142,7 +142,6 @@ def load_dataset(dataset_name, return_X_y=False, **kwargs):
     if dataset_name not in dataset_raw_files:
         raise Exception(f'Unknown Dataset: {dataset_name}')
 
-    # XXX cache this
     dset = dataset_raw_files[dataset_name]['load_function'](**kwargs)
 
     if return_X_y:

--- a/src/data/frey-faces.txt
+++ b/src/data/frey-faces.txt
@@ -8,7 +8,7 @@ Data Set Characteristics:
     :Number of Attributes: 560
     :Attribute Information: 20x28 8-bit greyscale image
     :Missing Attribute Values: None
-    :Creator: 
+    :Creator:
     :Date: 2017
 
 1965 images of Brendan Frey's face, taken from sequential frames of a
@@ -17,12 +17,5 @@ small video. Size: 20x28.
 Note, there is no target data associated with this dataset, so it is
 of use mainly in unsupervised algorithms.
 
-This is taken from 
+This is taken from
 https://cs.nyu.edu/~roweis/data.html
-
-References
-----------
-  - [F-MNIST] Fashion-MNIST: a Novel Image Dataset for Benchmarking Machine Learning Algorithms.
-    Han Xiao, Kashif Rasul, Roland Vollgraf. arXiv:1708.07747
-
-

--- a/src/data/frey-faces.txt
+++ b/src/data/frey-faces.txt
@@ -1,0 +1,28 @@
+Frey Faces
+==========
+
+Notes
+-----
+Data Set Characteristics:
+    :Number of Instances: 1965
+    :Number of Attributes: 560
+    :Attribute Information: 20x28 8-bit greyscale image
+    :Missing Attribute Values: None
+    :Creator: 
+    :Date: 2017
+
+1965 images of Brendan Frey's face, taken from sequential frames of a
+small video. Size: 20x28.
+
+Note, there is no target data associated with this dataset, so it is
+of use mainly in unsupervised algorithms.
+
+This is taken from 
+https://cs.nyu.edu/~roweis/data.html
+
+References
+----------
+  - [F-MNIST] Fashion-MNIST: a Novel Image Dataset for Benchmarking Machine Learning Algorithms.
+    Han Xiao, Kashif Rasul, Roland Vollgraf. arXiv:1708.07747
+
+

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -3,7 +3,8 @@ import click
 import logging
 from pathlib import Path
 from dotenv import find_dotenv, load_dotenv
-from .datasets import fetch_and_process, available_datasets
+from .utils import fetch_and_unpack
+from .datasets import available_datasets, load_dataset
 from ..paths import data_path
 
 @click.command()
@@ -11,7 +12,7 @@ from ..paths import data_path
 def main(action, datasets=None):
     """Fetch and/or process the raw data
 
-    Raw files are downloaded to 
+    Raw files are downloaded to
 Runs data processing scripts to turn raw data from (../raw) into
         cleaned data ready to be analyzed (saved in ../processed).
 
@@ -30,10 +31,9 @@ Runs data processing scripts to turn raw data from (../raw) into
     unpacked_datasets = {}
     for dataset_name in datasets:
         if action == 'fetch':
-            unpacked_datasets[dataset_name] = fetch_and_process(dataset_name, do_unpack=False)
+            unpacked_datasets[dataset_name] = fetch_and_unpack(dataset_name, do_unpack=False)
         elif action == 'process':
-            unpacked_datasets[dataset_name] = fetch_and_process(dataset_name, do_unpack=True)
-            
+            ds = load_dataset(dataset_name)
 
 
 if __name__ == '__main__':

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -12,14 +12,12 @@ from ..paths import data_path
 def main(action, datasets=None):
     """Fetch and/or process the raw data
 
-    Raw files are downloaded to
-Runs data processing scripts to turn raw data from (../raw) into
-        cleaned data ready to be analyzed (saved in ../processed).
+    Runs data processing scripts to turn raw data from (../raw) into
 
     Raw files are downloaded into `project_dir`/data/raw
     Interim files are generated in `project_dir`/data/interim
 
-    action: {'fetch', 'unpack', 'process'}
+    action: {'fetch', 'process'}
 
     """
     logger = logging.getLogger(__name__)

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -3,29 +3,37 @@ import click
 import logging
 from pathlib import Path
 from dotenv import find_dotenv, load_dotenv
-from .datasets import fetch_and_unpack, available_datasets
+from .datasets import fetch_and_process, available_datasets
+from ..paths import data_path
 
 @click.command()
-@click.argument('project_dir', type=click.Path(exists=True))
-def main(project_dir, datasets=None):
-    """ Runs data processing scripts to turn raw data from (../raw) into
+@click.argument('action')
+def main(action, datasets=None):
+    """Fetch and/or process the raw data
+
+    Raw files are downloaded to 
+Runs data processing scripts to turn raw data from (../raw) into
         cleaned data ready to be analyzed (saved in ../processed).
 
     Raw files are downloaded into `project_dir`/data/raw
     Interim files are generated in `project_dir`/data/interim
 
+    action: {'fetch', 'unpack', 'process'}
+
     """
     logger = logging.getLogger(__name__)
-    logger.info('making final data set from raw data')
+    logger.info(f'Dataset: running {action}')
 
     if datasets is None:
         datasets = available_datasets
 
-    data_dir = Path(project_dir) / 'data'
-
     unpacked_datasets = {}
     for dataset_name in datasets:
-        unpacked_datasets[dataset_name] = fetch_and_unpack(dataset_name, data_dir=data_dir)
+        if action == 'fetch':
+            unpacked_datasets[dataset_name] = fetch_and_process(dataset_name, do_unpack=False)
+        elif action == 'process':
+            unpacked_datasets[dataset_name] = fetch_and_process(dataset_name, do_unpack=True)
+            
 
 
 if __name__ == '__main__':

--- a/src/data/mnist.txt
+++ b/src/data/mnist.txt
@@ -1,0 +1,33 @@
+MNIST
+=====
+
+Notes
+-----
+Data Set Characteristics:
+    :Number of Instances: 70000
+    :Number of Attributes: 728
+    :Attribute Information: 28x28 8-bit greyscale image
+    :Missing Attribute Values: None
+    :Creator: LeCun et al
+    :Date: 1998
+
+This is a copy of the well-known MNIST database of handwritten digits,
+available from http://yann.lecun.com/exdb/mnist/
+
+The MNIST database of handwritten digits consists of a training set of
+60,000 examples, and a test set of 10,000 examples. It is a subset of
+a larger set available from NIST. The digits have been size-normalized
+and centered in a fixed-size image.
+
+The original black and white (bilevel) images from NIST were size
+normalized to fit in a 20x20 pixel box while preserving their aspect
+ratio. The resulting images contain grey levels as a result of the
+anti-aliasing technique used by the normalization algorithm. the
+images were centered in a 28x28 image by computing the center of mass
+of the pixels, and translating the image so as to position this point
+at the center of the 28x28 field.
+
+
+References
+
+[LeCun et al., 1998a]  Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner. "Gradient-based learning applied to document recognition." Proceedings of the IEEE, 86(11):2278-2324, November 1998.

--- a/src/data/synthetic.py
+++ b/src/data/synthetic.py
@@ -109,7 +109,6 @@ def sample_ball(n_points, n_dim=3, random_state=0):
 
     Use rejection sampling on the unit cube
     '''
-
     np.random.seed(random_state)
     points = []
     labels = []

--- a/src/data/synthetic.py
+++ b/src/data/synthetic.py
@@ -155,8 +155,8 @@ def helix(n_points=1000, random_state=None, noise=None,
     y = (major_radius + minor_radius * cosnt) * np.sin(t)
     z = minor_radius * np.sin(n_twists * t)
     X = np.concatenate((x,y,z))
-    if noise:
-        X += noise * generator.randn(3, n_points)
     X = X.T
     t = np.linalg.norm(X, axis=1)
+    if noise:
+        X += noise * generator.randn(n_points, 3)
     return X, t

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -176,7 +176,9 @@ def unpack(filename, dst_dir=None, create_dst=True):
         opener, mode = gzip.open, 'rb'
         outfile, outmode = path[:-3], 'wb'
     else:
-        raise ValueError(f"Could not extract {path} as no appropriate extractor is found")
+        opener, mode = open, 'rb'
+        outfile, outmode = path, 'wb'
+        logger.info("No compression detected. Copying...")
 
     with opener(filename, mode) as f_in:
         if archive:

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -8,7 +8,7 @@ import shutil
 import zipfile
 import gzip
 
-from ..paths import interim_data_path
+from ..paths import interim_data_path, raw_data_path
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ def fetch_files(force=False, dst_dir=None, **kwargs):
     '''
     url_list = kwargs.get('url_list', None)
     if not url_list:
-        raise Exception(f"url_list is a required keyword argument: {kwargs}")
+        return fetch_file(force=force, dst_dir=dst_dir, **kwargs)
     result_list = []
     for url_dict in url_list:
         name = url_dict.get('name', 'dataset')
@@ -100,17 +100,17 @@ def fetch_file(url,
     if `raw_file` already exists, compute the hash of the on-disk file,
     '''
     if dst_dir is None:
-        dst_dir = pathlib.Path(".")
+        dst_dir = raw_data_path
     if raw_file is None:
         raw_file = url.split("/")[-1]
-    raw_data_path = pathlib.Path(dst_dir)
+    dl_data_path = pathlib.Path(dst_dir)
 
-    if not os.path.exists(raw_data_path):
-        os.makedirs(raw_data_path)
+    if not os.path.exists(dl_data_path):
+        os.makedirs(dl_data_path)
 
-    raw_data_file = raw_data_path / raw_file
+    raw_data_file = dl_data_path / raw_file
 
-    if os.path.exists(raw_data_file):
+    if raw_data_file.exists():
         raw_file_hash = hash_file(raw_data_file, algorithm=hash_type).hexdigest()
         if hash_value is not None:
             if raw_file_hash == hash_value:

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -18,7 +18,6 @@ hash_function = {
     'md5': hashlib.md5,
 }
 
-
 def hash_file(fname, algorithm="sha1", block_size=4096):
     '''Compute the hash of an on-disk file
 
@@ -188,3 +187,13 @@ def unpack(filename, dst_dir=None, create_dst=True):
             logger.info(f"Decompresing {outfile}")
             with open(pathlib.Path(dst_dir) / outfile, outmode) as f_out:
                 shutil.copyfileobj(f_in, f_out)
+
+def build_dataset_dict(hash_type='sha1', hash_value=None, url=None, name=None):
+    """fetch a URL, return a dataset dictionary entry"""
+    fetch_dict = {'url': url, 'hash_type':hash_type, 'hash_value':hash_value, 'name': name}
+    status, path, hash_value = fetch_files(**fetch_dict)
+    if status:
+        fetch_dict['hash_value'] = hash_value
+        return fetch_dict
+
+    raise Exception(f"fetch of {url} returned status: {status}")

--- a/src/visualization/plotting.py
+++ b/src/visualization/plotting.py
@@ -76,7 +76,7 @@ def plot_3d_dataset(data, color_data, title='3d plot', figsize=(8,8), dim_list=N
              c=color_data, cmap=cmap)
     ax.view_init(10)
     plt.title(title)
-    plt.show()
+    return ax
 
 def sphere_plot(data, color_data, wireframe=False, s=50, zorder=10, dim_list=None, cmap=None,
                 figsize=(8,8), **kwargs):

--- a/src/visualization/plotting.py
+++ b/src/visualization/plotting.py
@@ -69,7 +69,7 @@ def plot_3d_dataset(data, color_data, title='3d plot', figsize=(8,8), dim_list=N
         dim_list = [0, 1, 2]
     if cmap is None:
         cmap = plt.cm.Spectral
-        
+
     fig = plt.figure(figsize=figsize)
     ax = fig.add_subplot(111, projection='3d')
     ax.scatter(data[:, dim_list[0]], data[:, dim_list[1]], data[:, dim_list[2]],
@@ -87,7 +87,7 @@ def sphere_plot(data, color_data, wireframe=False, title='sphere plot',
         dim_list = [0, 1, 2]
     if cmap is None:
         cmap = plt.cm.Spectral
-    
+
     fig = plt.figure(figsize=figsize)
     ax = fig.add_subplot(111, projection='3d', aspect='equal')
     if wireframe:

--- a/src/visualization/plotting.py
+++ b/src/visualization/plotting.py
@@ -78,7 +78,8 @@ def plot_3d_dataset(data, color_data, title='3d plot', figsize=(8,8), dim_list=N
     plt.title(title)
     return ax
 
-def sphere_plot(data, color_data, wireframe=False, s=50, zorder=10, dim_list=None, cmap=None,
+def sphere_plot(data, color_data, wireframe=False, title='sphere plot',
+                s=50, zorder=10, dim_list=None, cmap=None,
                 figsize=(8,8), **kwargs):
     '''
     '''
@@ -99,3 +100,5 @@ def sphere_plot(data, color_data, wireframe=False, s=50, zorder=10, dim_list=Non
     ax.scatter(data[:, dim_list[0]], data[:, dim_list[1]], data[:, dim_list[2]],
              c=color_data, cmap=cmap, s=s, zorder=zorder, **kwargs)
 
+    plt.title(title)
+    return ax


### PR DESCRIPTION
Split the fetch and process parts of the pipeline
add joblib caching to dataset generation
fix up the synthetic datasets a bit by moving noise generaation
Add 2 new datasets: MNIST and frey-faces
Add utility functions for extending dataset list
Move dataset list of external (json) serialization
Better conform with matplotlib API