### PR TITLE
update to use implementation of tsne extending BaseEstimator

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,5 +30,5 @@ dependencies:
   - pip:
     - -e .
     - pytest-cov
-    - git+https://github.com/acwooding/Multicore-TSNE.git@add-repr
+    - git+https://github.com/acwooding/Multicore-TSNE.git@make-base-estimator
     - coveralls


### PR DESCRIPTION
Was using a hack before that didn't fully support the sklearn API necessary to do GridSearchCV. Should be fixed in this branch.