### PR TITLE
Comment out coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             source activate dimension_reduction
             cd src
             pytest --doctest-modules --doctest-continue-on-failure --verbose --cov --junitxml=test-reports/junit.xml
-            COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN coveralls
+            #COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN coveralls
 
       - store_test_results:
           path: test-reports


### PR DESCRIPTION
Coveralls is failing to upload regularly, but non-deterministically which fails the CI tests. Comment it out for the time being until we can fix it (or replace it with something else). 